### PR TITLE
small patch to convert numpy.int64 to python int

### DIFF
--- a/src/modular_inference_benchmark/engine/distributions.py
+++ b/src/modular_inference_benchmark/engine/distributions.py
@@ -86,7 +86,7 @@ class AdjustedUniformInt(Distribution):
         rval = np.empty(len(lengths), dtype=np.int64)
         for i, length in enumerate(lengths):
             rval[i] = np.random.randint(self.low, self.high - length)
-        return list(rval)
+        return list(rval.tolist())
 
 
 DISTRIBUTION_CLASSES = {


### PR DESCRIPTION
Fix small error for storing output as json file.
AdjustedUniformInt generates numpy.int64 elements which throws:
TypeError: Object of type int64 is not JSON serializable
calling tolist() to convert to python int