### PR TITLE
[Bugfix] Rename main.py to __main__.py

### DIFF
--- a/src/flexible_inference_benchmark/__main__.py
+++ b/src/flexible_inference_benchmark/__main__.py
@@ -1,0 +1,4 @@
+import main
+
+if __name__ == "__main__":
+    main.main()


### PR DESCRIPTION
Rename main.py to __main__.py to allow executing package again.