### PR TITLE
[FIX] Solve TPOT error

### DIFF
--- a/src/flexible_inference_benchmark/data_postprocessors/performance.py
+++ b/src/flexible_inference_benchmark/data_postprocessors/performance.py
@@ -40,9 +40,9 @@ def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, st
     mean_ttft_ms = np.mean(ttfts or 0) * 1000
     median_ttft_ms = np.median(ttfts or 0) * 1000
     p99_ttft_ms = np.percentile(ttfts or 0, 99) * 1000
-    mean_tpot_ms = np.mean(tpots) * 1000
-    median_tpot_ms = np.median(tpots) * 1000
-    p99_tpot_ms = np.percentile(tpots, 99) * 1000
+    mean_tpot_ms = np.mean(tpots or 0) * 1000
+    median_tpot_ms = np.median(tpots or 0) * 1000
+    p99_tpot_ms = np.percentile(tpots or 0, 99) * 1000
     mean_itl_ms = np.mean(itls or 0) * 1000
     median_itl_ms = np.median(itls or 0) * 1000
     p99_itl_ms = np.percentile(itls or 0, 99) * 1000


### PR DESCRIPTION
Fix TPOT error when the output is only 1 token

Now results will look like:
```
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
/home/john/Documents/centml/cserve-project/flexible-inference-bench/venv/lib/python3.10/site-packages/transformers/tokenization_utils_base.py:1617: FutureWarning: `clean_up_tokenization_spaces` was not set. It will be set to `True` by default. This behavior will be deprecated in transformers v4.45, and will be then set to `False` by default. For more details check this issue: https://github.com/huggingface/transformers/issues/31884
  warnings.warn(
============ Serving Benchmark Result ============
Successful requests:                     100       
Benchmark duration (s):                  20.89     
Total input tokens:                      19921     
Total generated tokens:                  100       
Request throughput (req/s):              4.79      
Input token throughput (tok/s):          953.83    
Output token throughput (tok/s):         4.79      
---------------Time to First Token----------------
Mean TTFT (ms):                          25.56     
Median TTFT (ms):                        27.15     
P99 TTFT (ms):                           34.18     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.00      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.00      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
==================================================
```