### PR TITLE
Use "resource" library to set open files limit

### DIFF
--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -9,7 +9,7 @@ from typing import List, Any, Tuple, Union
 import numpy as np
 from transformers import AutoTokenizer
 from flexible_inference_benchmark.engine.distributions import DISTRIBUTION_CLASSES, Distribution
-from flexible_inference_benchmark.utils.utils import configure_logging
+from flexible_inference_benchmark.utils.utils import configure_logging, set_max_open_files
 from flexible_inference_benchmark.engine.data import ShareGPT, Textfile, Random
 from flexible_inference_benchmark.engine.client import Client
 from flexible_inference_benchmark.engine.backend_functions import ASYNC_REQUEST_FUNCS
@@ -258,6 +258,8 @@ def run_main(args: argparse.Namespace) -> None:
     min_length = min(len(requests_prompts), len(requests_times))
     requests_prompts = requests_prompts[:min_length]
     requests_times = requests_times[:min_length]
+
+    set_max_open_files(min_length + 256)
 
     args.api_url = f"{args.base_url}{args.endpoint}"
 

--- a/src/flexible_inference_benchmark/utils/utils.py
+++ b/src/flexible_inference_benchmark/utils/utils.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import logging
 import argparse
 import resource
@@ -13,6 +15,7 @@ def configure_logging(args: argparse.Namespace) -> None:
         level=logging.DEBUG if args.debug else logging.INFO,
     )
 
+
 # adapted from: https://github.com/vllm-project/vllm/blob/e1a5c2f0a123835558b1b1c9895181161527c55e/vllm/utils.py#L1857
 def set_max_open_files(n: Optional[int]) -> None:
     """Try to expand the system limit on the maximum number of open files."""
@@ -20,7 +23,8 @@ def set_max_open_files(n: Optional[int]) -> None:
     if n is not None and n > hard:
         logger.warning(
             "Number of requests exceeds maximum ulimit for number of open files"
-            "Consider increasing the limit with ulimit -n")
+            "Consider increasing the limit with ulimit -n"
+        )
     target_amount = n or 65535
     request_amount = max(soft, min(hard, target_amount))
     if request_amount == soft:
@@ -34,4 +38,8 @@ def set_max_open_files(n: Optional[int]) -> None:
             "Failed to increase ulimit from %s to %s."
             "This can lead to errors for large amounts of requests."
             "Consider increasing the limit with ulimit -n."
-            "Error: %s", soft, request_amount, e)
+            "Error: %s",
+            soft,
+            request_amount,
+            e,
+        )

--- a/src/flexible_inference_benchmark/utils/utils.py
+++ b/src/flexible_inference_benchmark/utils/utils.py
@@ -1,5 +1,6 @@
 import logging
 import argparse
+import resource
 
 logger = logging.getLogger(__name__)
 
@@ -11,3 +12,26 @@ def configure_logging(args: argparse.Namespace) -> None:
         datefmt="%Y-%m-%d %H:%M",
         level=logging.DEBUG if args.debug else logging.INFO,
     )
+
+# adapted from: https://github.com/vllm-project/vllm/blob/e1a5c2f0a123835558b1b1c9895181161527c55e/vllm/utils.py#L1857
+def set_max_open_files(n: Optional[int]) -> None:
+    """Try to expand the system limit on the maximum number of open files."""
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    if n is not None and n > hard:
+        logger.warning(
+            "Number of requests exceeds maximum ulimit for number of open files"
+            "Consider increasing the limit with ulimit -n")
+    target_amount = n or 65535
+    request_amount = max(soft, min(hard, target_amount))
+    if request_amount == soft:
+        return
+
+    logger.debug("Setting max open files limit to %d of upper limit %d", request_amount, hard)
+    try:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (request_amount, hard))
+    except ValueError as e:
+        logger.warning(
+            "Failed to increase ulimit from %s to %s."
+            "This can lead to errors for large amounts of requests."
+            "Consider increasing the limit with ulimit -n."
+            "Error: %s", soft, request_amount, e)


### PR DESCRIPTION
Should solve #74 

Tested manually and works for up to 20k concurrent requests, at which point a different error seems to arise.

vLLM has a similar fix implemented, but my experiments with CServe and vLLM both exhibited the same problem on the other side of the connection when `ulimit -n` was not set for the server. We should consider adding the same fix into the CServe server.