### PR TITLE
Misc Quality-of-Life improvements

### DIFF
--- a/examples/cserve_args.json
+++ b/examples/cserve_args.json
@@ -8,6 +8,5 @@
     "request_distribution": ["poisson", 5],
     "num_of_req": 20,
     "model": "gpt2",
-    "tokenizer": "gpt2",
-    "no_prefix": true
+    "tokenizer": "gpt2"
 }

--- a/examples/trt_llm_args.json
+++ b/examples/trt_llm_args.json
@@ -8,6 +8,5 @@
     "request_distribution": ["poisson", 5],
     "num_of_req": 20,
     "model": "google/gemma-2b",
-    "tokenizer": "google/gemma-2b",
-    "no_prefix": true
+    "tokenizer": "google/gemma-2b"
 }

--- a/examples/vllm_args.json
+++ b/examples/vllm_args.json
@@ -2,12 +2,10 @@
     "backend": "vllm",
     "base_url": "http://localhost:8000",
     "endpoint": "/v1/completions",
-    "dataset_name": "random",
-    "input_token_distribution": ["normal", 200, 10],
-    "output_token_distribution": ["uniform", 200, 201],
-    "request_distribution": ["poisson", 5],
-    "num_of_req": 20,
-    "model": "gpt2",
-    "tokenizer": "gpt2",
-    "no_prefix": true
+    "dataset_name": "sharegpt",
+    "dataset_path": "sharegpt.json",
+    "request_distribution": ["poisson", 1],
+    "num_of_req": 100,
+    "model": "meta-llama/Meta-Llama-3.1-405B-FP8",
+    "tokenizer": "meta-llama/Llama-3.1-8B-Instruct"
 }

--- a/src/flexible_inference_benchmark/data_postprocessors/performance.py
+++ b/src/flexible_inference_benchmark/data_postprocessors/performance.py
@@ -9,8 +9,8 @@ from transformers import AutoTokenizer
 
 
 def add_performance_parser(subparsers: argparse._SubParsersAction) -> None:
-    performance_parser = subparsers.add_parser('analyse')
-    performance_parser.add_argument("--datapath", type=str, required=True, help='Path to the json file')
+    performance_parser = subparsers.add_parser('analyse', help="Summarize the performance of a benchmark record")
+    performance_parser.add_argument("datapath", type=str, help='Path to the json file')
 
 
 def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, stream):
@@ -22,7 +22,10 @@ def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, st
     ttfts = []
     for i in range(len(outputs)):
         if outputs[i]["success"]:
-            output_len = len(tokenizer(outputs[i]["generated_text"], add_special_tokens=False).input_ids)
+            if "output_len" in outputs[i]:
+                output_len = outputs[i]["output_len"]
+            else:
+                output_len  = len(tokenizer(outputs[i]["generated_text"], add_special_tokens=False).input_ids)
             actual_output_lens.append(output_len)
             total_input += input_requests[i][1]
             if output_len > 1:

--- a/src/flexible_inference_benchmark/data_postprocessors/performance.py
+++ b/src/flexible_inference_benchmark/data_postprocessors/performance.py
@@ -13,7 +13,7 @@ def add_performance_parser(subparsers: argparse._SubParsersAction) -> None:
     performance_parser.add_argument("datapath", type=str, help='Path to the json file')
 
 
-def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, stream):
+def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, stream) -> None:
     actual_output_lens = []
     total_input = 0
     completed = 0
@@ -25,7 +25,7 @@ def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, st
             if "output_len" in outputs[i]:
                 output_len = outputs[i]["output_len"]
             else:
-                output_len  = len(tokenizer(outputs[i]["generated_text"], add_special_tokens=False).input_ids)
+                output_len = len(tokenizer(outputs[i]["generated_text"], add_special_tokens=False).input_ids)
             actual_output_lens.append(output_len)
             total_input += input_requests[i][1]
             if output_len > 1:

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -254,7 +254,7 @@ async def async_request_openai_completions(
                 "max_tokens": request_func_input.output_len,
                 "stream": True,
                 "ignore_eos": request_func_input.ignore_eos,
-                "stream_options": {"include_usage": True}
+                "stream_options": {"include_usage": True},
             }
             headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
 
@@ -302,7 +302,7 @@ async def async_request_openai_completions(
 
                                     most_recent_timestamp = timestamp
                                     generated_text += data["choices"][0]["text"]
-                        
+
                                 if data["usage"]:
                                     output.output_len = data["usage"]["completion_tokens"]
 

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -47,7 +47,12 @@ class Client:
         return ASYNC_REQUEST_FUNCS[self.backend]
 
     async def send_request(
-        self, idx: int, data: RequestFuncInput, wait_time: float, pbar: Optional[tqdm], sema: Optional[asyncio.BoundedSemaphore]
+        self,
+        idx: int,
+        data: RequestFuncInput,
+        wait_time: float,
+        pbar: Optional[tqdm],
+        sema: Optional[asyncio.BoundedSemaphore],
     ) -> Optional[Union[RequestFuncOutput, Any]]:
         await asyncio.sleep(wait_time)
         if sema:

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -25,6 +25,7 @@ class Client:
         stream: bool,
         cookies: Dict[str, str],
         verbose: bool,
+        max_concurrent: Optional[int],
     ):
         self.backend = backend
         self.api_url = api_url
@@ -37,6 +38,7 @@ class Client:
         self.stream = stream
         self.cookies = cookies
         self.verbose = verbose
+        self.max_concurrent = max_concurrent
 
     @property
     def request_func(
@@ -45,10 +47,14 @@ class Client:
         return ASYNC_REQUEST_FUNCS[self.backend]
 
     async def send_request(
-        self, idx: int, data: RequestFuncInput, wait_time: float, pbar: Optional[tqdm]
+        self, idx: int, data: RequestFuncInput, wait_time: float, pbar: Optional[tqdm], sema: Optional[asyncio.BoundedSemaphore]
     ) -> Optional[Union[RequestFuncOutput, Any]]:
         await asyncio.sleep(wait_time)
-        return await self.request_func(idx, data, pbar, self.verbose, wait_time)
+        if sema:
+            async with sema:
+                return await self.request_func(idx, data, pbar, self.verbose, wait_time)
+        else:
+            return await self.request_func(idx, data, pbar, self.verbose, wait_time)
 
     async def benchmark(
         self, data: List[Tuple[str, int, int]], request_times: List[Union[float, int]]
@@ -73,9 +79,11 @@ class Client:
             for data_sample in data
         ]
 
+        sema = asyncio.BoundedSemaphore(self.max_concurrent) if self.max_concurrent else None
+
         return await asyncio.gather(
             *[
-                self.send_request(idx, data, request_time, pbar)
+                self.send_request(idx, data, request_time, pbar, sema)
                 for idx, (data, request_time) in enumerate(zip(request_func_inputs, request_times))
             ]
         )
@@ -94,4 +102,4 @@ class Client:
             stream=self.stream,
             cookies=self.cookies,
         )
-        return await self.send_request(0, data, 0, None)
+        return await self.send_request(0, data, 0, None, None)

--- a/src/flexible_inference_benchmark/engine/workloads.py
+++ b/src/flexible_inference_benchmark/engine/workloads.py
@@ -27,7 +27,7 @@ class Story(BaseWorkload):
 
 
 class Rag(BaseWorkload):
-    input_token_distribution: List[Union[str, int]] = ['uniform', 4000, 200]
+    input_token_distribution: List[Union[str, int]] = ['normal', 4000, 200]
     output_token_distribution: List[Union[str, int]] = ['normal', 1000, 5]
 
 

--- a/src/flexible_inference_benchmark/engine/workloads.py
+++ b/src/flexible_inference_benchmark/engine/workloads.py
@@ -35,4 +35,5 @@ class Tiny(BaseWorkload):
     input_token_distribution: List[Union[str, int]] = ['uniform', 5, 7]
     output_token_distribution: List[Union[str, int]] = ['uniform', 5, 7]
 
+
 WORKLOADS_TYPES = {"general": General, "summary": Summary, "story": Story, "rag": Rag, "tiny": Tiny}

--- a/src/flexible_inference_benchmark/engine/workloads.py
+++ b/src/flexible_inference_benchmark/engine/workloads.py
@@ -31,4 +31,8 @@ class Rag(BaseWorkload):
     output_token_distribution: List[Union[str, int]] = ['normal', 1000, 5]
 
 
-WORKLOADS_TYPES = {"general": General, "summary": Summary, "story": Story, "rag": Rag}
+class Tiny(BaseWorkload):
+    input_token_distribution: List[Union[str, int]] = ['uniform', 5, 7]
+    output_token_distribution: List[Union[str, int]] = ['uniform', 5, 7]
+
+WORKLOADS_TYPES = {"general": General, "summary": Summary, "story": Story, "rag": Rag, "tiny": Tiny}

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -299,6 +299,8 @@ def parse_args() -> argparse.Namespace:
                 args.model = model
         if not args.endpoint:
             args.endpoint = try_find_endpoint(args.base_url, openapi)
+        if args.endpoint and args.endpoint[0] != '/':
+            args.endpoint = "/" + args.endpoint
         
         if not args.dataset_path and args.dataset_name == 'sharegpt':
             # download the sharegpt dataset and cache it in the home directory

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -238,7 +238,11 @@ def parse_args() -> argparse.Namespace:
         if not (args.prefix_text or args.prefix_len or args.no_prefix):
             parser.error("Please provide either prefix text or prefix length or specify no prefix.")
         if not (args.num_of_req or args.max_time_for_reqs):
-            parser.error("Please provide either number of requests or max time for requests.")
+            logger.info("Number of requests and max time for requests not provided. Defaulting to 1 request.")
+            args.num_of_req = 1
+        if not args.base_url:
+            logger.info("Base url not provided. Defaulting to http://localhost:8000")
+            args.base_url = "http://localhost:8000"
         if not args.model:
             parser.error("Please provide the model name.")
 

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -9,7 +9,7 @@ from typing import List, Any, Tuple, Union
 import numpy as np
 from transformers import AutoTokenizer
 from flexible_inference_benchmark.engine.distributions import DISTRIBUTION_CLASSES, Distribution
-from flexible_inference_benchmark.utils.utils import configure_logging
+from flexible_inference_benchmark.utils.utils import configure_logging, try_find_model
 from flexible_inference_benchmark.engine.data import ShareGPT, Textfile, Random
 from flexible_inference_benchmark.engine.client import Client
 from flexible_inference_benchmark.engine.backend_functions import ASYNC_REQUEST_FUNCS

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -244,7 +244,13 @@ def parse_args() -> argparse.Namespace:
             logger.info("Base url not provided. Defaulting to http://localhost:8000")
             args.base_url = "http://localhost:8000"
         if not args.model:
-            parser.error("Please provide the model name.")
+            logger.info("Model name not provided. Trying to query the model name from the server.")
+            model = try_find_model(args.base_url)
+            if model is None:
+                parser.error("Model could not be deduced automatically. Please provide the model name.")
+            else:
+                logger.info(f"Model identified: {model}")
+                args.model = model
 
     return args
 

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -138,6 +138,8 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> None:  # 
 
     req_group.add_argument("--max-time-for-reqs", "--timeout", type=int, default=None, help="Max time for requests in seconds.")
 
+    benchmark_parser.add_argument("--max-concurrent", type=int, default=None, help="Optional limit on the number of concurrent in-flight requests.")
+
     benchmark_parser.add_argument(
         "--request-distribution",
         nargs="*",
@@ -313,6 +315,7 @@ def run_main(args: argparse.Namespace) -> None:
         not args.disable_stream,
         args.cookies,
         args.verbose,
+        args.max_concurrent
     )
     # disable verbose output for validation of the endpoint. This is done to avoid confusion on terminal output.
     client_verbose_value = client.verbose

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -218,7 +218,7 @@ def parse_args() -> argparse.Namespace:
 
     parser = argparse.ArgumentParser(description="CentML Inference Benchmark")
 
-    subparsers = parser.add_subparsers(title='Subcommands', dest='subcommand')
+    subparsers = parser.add_subparsers(title='Subcommands', dest='subcommand', required=True)
 
     add_performance_parser(subparsers)
     add_benchmark_subparser(subparsers)
@@ -316,8 +316,10 @@ def main() -> None:
         from flexible_inference_benchmark.data_postprocessors.itl import run
 
         run(args)
-    else:
+    elif args.subcommand == "benchmark":
         run_main(args)
+    else:
+        raise ValueError(f"Invalid subcommand {args.subcommand}")
 
 
 if __name__ == '__main__':

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -233,6 +233,8 @@ def parse_args() -> argparse.Namespace:
             for k, v in file_data.items():
                 # Reload arguments to override config file values with command line values
                 setattr(args, k, v)
+
+        configure_logging(args)
         if not (args.prefix_text or args.prefix_len or args.no_prefix):
             parser.error("Please provide either prefix text or prefix length or specify no prefix.")
         if not (args.num_of_req or args.max_time_for_reqs):
@@ -244,7 +246,6 @@ def parse_args() -> argparse.Namespace:
 
 
 def run_main(args: argparse.Namespace) -> None:
-    configure_logging(args)
     if args.workload_type:
         workload_type = WORKLOADS_TYPES[args.workload_type]()
         workload_type.overwrite_args(args)

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -169,7 +169,7 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> None:  # 
 
     prefix_group.add_argument("--prefix-len", type=int, default=None, help="Length of prefix to use for all requests.")
 
-    prefix_group.add_argument('--no-prefix', action='store_true', help='No prefix for requests.')
+    prefix_group.add_argument('--no-prefix', type=bool, default=True, help='No prefix for requests, default is True.')
 
     benchmark_parser.add_argument("--disable-ignore-eos", action="store_true", help="Disables ignoring the eos token")
 

--- a/src/flexible_inference_benchmark/utils/utils.py
+++ b/src/flexible_inference_benchmark/utils/utils.py
@@ -16,20 +16,57 @@ def configure_logging(args: argparse.Namespace) -> None:
         level=logging.DEBUG if show_debug_logs else logging.INFO,
     )
 
-def try_find_model(base_url) -> Optional[str]:
+def try_find_model(base_url: str, openapi: Optional[dict]) -> Optional[str]:
     """
     Query the base URL for models and return the first model ID. Assumes an OpenAI-like API.
 
     Args:
         base_url (str): The URL to query.
+        openapi (dict): Optional JSON object describing the API.
 
     Returns:
         Optional[str]: The first model ID, or None if the request fails.
     """
+    try_paths = ["/v1/models", "/openai/v1/models", "/models"]
+    if openapi:
+        try_paths = filter(lambda path: path in openapi["paths"].keys(), try_paths)
+    try_urls = [f"{base_url}{path}" for path in try_paths]
+    resp_json = None
+    for url in try_urls:
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            resp_json = response.json()
+            break
+        except:
+            continue
 
-    try:
-        response = requests.get(f"{base_url}/v1/models")
-        response.raise_for_status()
-        return response.json()["data"][0]["id"]
-    except Exception as e:
-        return None
+    if resp_json is not None and "models" in resp_json:
+        return resp_json["models"][0]["id"]
+    elif resp_json is not None and "data" in resp_json:
+        return resp_json["data"][0]["id"]
+    return None
+
+def try_find_endpoint(base_url: str, openapi: Optional[dict]) -> Optional[str]:
+    """
+    Query the base URL for endpoints and return any that exist.
+
+    Args:
+        base_url (str): The URL to query.
+        openapi (dict): Optional JSON object describing the API.
+
+    Returns:
+        Optional[str]: The path of the identified endpoint, or None if no endpoint was found.
+    """
+    try_paths = ["/v1/completions", "/openai/v1/completions", "/generate_stream", "/v1/generate", "/generate"]
+    if openapi:
+        try_paths = filter(lambda path: path in openapi["paths"].keys(), try_paths)
+    for path in try_paths:
+        try:
+            response = requests.post(f"{base_url}{path}")
+            if response.ok or response.status_code == 400:
+                return path # 400 means the endpoint exists, just that the request wasn't proper
+            response.raise_for_status()
+            break
+        except:
+            continue

--- a/src/flexible_inference_benchmark/utils/utils.py
+++ b/src/flexible_inference_benchmark/utils/utils.py
@@ -60,7 +60,11 @@ def try_find_endpoint(base_url: str, openapi: Optional[dict]) -> Optional[str]:
     """
     try_paths = ["/v1/completions", "/openai/v1/completions", "/generate_stream", "/v1/generate", "/generate"]
     if openapi:
-        try_paths = filter(lambda path: path in openapi["paths"].keys(), try_paths)
+        try_paths = list(filter(lambda path: path in openapi["paths"].keys(), try_paths))
+    
+    if len(try_paths) == 1:
+        return try_paths[0]
+        
     for path in try_paths:
         try:
             response = requests.post(f"{base_url}{path}")
@@ -70,3 +74,5 @@ def try_find_endpoint(base_url: str, openapi: Optional[dict]) -> Optional[str]:
             break
         except:
             continue
+    
+    return None

--- a/src/flexible_inference_benchmark/utils/utils.py
+++ b/src/flexible_inference_benchmark/utils/utils.py
@@ -1,5 +1,8 @@
+from typing import Optional
+
 import logging
 import argparse
+import requests
 
 logger = logging.getLogger(__name__)
 
@@ -12,3 +15,21 @@ def configure_logging(args: argparse.Namespace) -> None:
         datefmt="%Y-%m-%d %H:%M",
         level=logging.DEBUG if show_debug_logs else logging.INFO,
     )
+
+def try_find_model(base_url) -> Optional[str]:
+    """
+    Query the base URL for models and return the first model ID. Assumes an OpenAI-like API.
+
+    Args:
+        base_url (str): The URL to query.
+
+    Returns:
+        Optional[str]: The first model ID, or None if the request fails.
+    """
+
+    try:
+        response = requests.get(f"{base_url}/v1/models")
+        response.raise_for_status()
+        return response.json()["data"][0]["id"]
+    except Exception as e:
+        return None

--- a/src/flexible_inference_benchmark/utils/utils.py
+++ b/src/flexible_inference_benchmark/utils/utils.py
@@ -108,3 +108,16 @@ def set_max_open_files(n: Optional[int]) -> None:
             request_amount,
             e,
         )
+
+def download_sharegpt_dataset(path: str) -> None:
+    """
+    Download the ShareGPT V3 dataset.
+
+    Args:
+        path (str): The path to save the dataset to.
+    """
+    url = "https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json"
+    response = requests.get(url)
+    response.raise_for_status()
+    with open(path, "wb") as f:
+        f.write(response.content)

--- a/src/flexible_inference_benchmark/utils/utils.py
+++ b/src/flexible_inference_benchmark/utils/utils.py
@@ -5,9 +5,10 @@ logger = logging.getLogger(__name__)
 
 
 def configure_logging(args: argparse.Namespace) -> None:
+    show_debug_logs = hasattr(args, "debug") and args.debug
 
     logging.basicConfig(
         format="%(asctime)s %(levelname)-8s %(message)s",
         datefmt="%Y-%m-%d %H:%M",
-        level=logging.DEBUG if args.debug else logging.INFO,
+        level=logging.DEBUG if show_debug_logs else logging.INFO,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,6 @@ def args_config():
         "num_of_req": 10, 
         "model": "gpt2",
         "tokenizer": "gpt2",
-        "no_prefix": True,
         "prefix_text": None,
         "prefix_len": None,
         "disable_ignore_eos": False,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import time
+from transformers import AutoTokenizer
 from flexible_inference_benchmark.main import generate_request_times, generate_prompts
 from flexible_inference_benchmark.engine.client import Client
 
@@ -14,7 +15,9 @@ def test_backend_function(vllm_server, args_config):
 
     requests_times = generate_request_times(args)
     size = len(requests_times)
-    requests_prompts = generate_prompts(args, size)
+    tokenizer_id = args.tokenizer if args.tokenizer else args.model
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_id)
+    requests_prompts = generate_prompts(args, tokenizer, size)
     min_length = min(len(requests_prompts), len(requests_times))
     requests_prompts = requests_prompts[:min_length]
     requests_times = requests_times[:min_length]
@@ -66,7 +69,7 @@ def test_backend_function(vllm_server, args_config):
 
     requests_times = generate_request_times(args)
     size = len(requests_times)
-    requests_prompts = generate_prompts(args, size)
+    requests_prompts = generate_prompts(args, tokenizer, size)
     min_length = min(len(requests_prompts), len(requests_times))
     requests_prompts = requests_prompts[:min_length]
     requests_times = requests_times[:min_length]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -35,6 +35,7 @@ def test_backend_function(vllm_server, args_config):
         not args.disable_stream,
         args.cookies,
         args.verbose,
+        None
     )
 
     t = time.perf_counter() 
@@ -87,6 +88,7 @@ def test_backend_function(vllm_server, args_config):
         not args.disable_stream,
         args.cookies,
         args.verbose,
+        None
     )
 
     t = time.perf_counter() 


### PR DESCRIPTION
# Overview

## Motivation

Using the flexible inference benchmarker has become tedious due to the reliance on config files. The tool clearly started as a CLI tool, but since there are so many configuration options (and many are very long) it is not practical to type out all the arguments in each call. So we have config files with all the arguments we need, and we modify them each time we want to change the setup. This is a lot of extra effort, especially when benchmarking repeatedly with different parameters. We have received feedback from POC users that the tool is burdensome to use.

This PR aims to restore the usage of the tool to the command-line, and reduce the dependence on config files for customization. Further, I hope to simplify the CLI options so that the tool is very quick and easy to use, with as little configuration needing to be changed between runs as possible. Some example usage in the new style is detailed at the last section.

## CLI Changes

- Added help messages to the "benchmark" and "analyse" subcommands
- More consistent punctuation in the help messages
- Entering a subcommand is now required. This seems obvious and should improve error messages when used incorrectly.
- **"analyse" parser:**
- - Made "datapath" a positional argument. It is the only argument anyway, and is required, so this is always equivalent but saves having to type "--datapath" each time.
- **"benchmark" parser:**
- - Removed "no_prefix" option. No prefix is now the default, and prefixes can be enabled by passing "prefix_len" or "prefix_str" as before.
- - Shorthand aliases: "-b" for backend, "-w" and "--workload" for workload type, "-n" for number of requests, "--timeout" for max-time-for-requests, "--rps N" for "--request-distribution poisson N", "--dataset" for "--dataset-name", "-m" for model, "-c" for config file
- "--num-of-req" is optional and defaults to sending a single request.
- "--max-concurrent" is a new argument, see below
- "--dataset-name" is now optional when "--dataset-path" is given, defaulting to "other".

## Other Changes

- Use "include_usage" option for openai completions interface when streaming is enabled. When supported, this saves the total number of output tokens reported by the server during benchmarking. This is used to more reliably determine the number of output tokens for analysis purposes. When not present, the tokenizer-based estimation is used as before. This resolves some (but not all) of the problematic cases from #66.
- Automatic polling to determine base_url, model, and endpoint when they are not provided:
- - By sending a GET request to localhost:8000 and localhost:8080, we can check if a server is running on the local network. This enables users to omit the "--base_url" option when benchmarking a local connection
- - By sending a GET request to the server, we can query the model. If the server is openapi-compliant, we can determine that path to query easily. Otherwise, we can try a few common options (such as "/v1/models"). This enables users to omit "--model" in most cases.
- - By sending a POST request to the server, we can identify which path is the completions endpoint by trying a few options and/or consulting the openapi specification. This enables the user to omit "--endpoint" in most cases.
- Change the default "backend" option to "openai". To my knowledge this only effects which request backend to use, for which "cserve", "vllm", and "openai" are equivalent.
- Run the analysis sub-tool via "calculate_metrics" to print the performance statistics after benchmarking. "fib analyse" still works, but a lot of the time we are just doing "fib benchmark ... && fib analyse ...", so this streamlines that use-case. "fib benchmark" also still outputs an artifact file for postprocessing and analysis.
- Add an additional workload type "Tiny" that has 5-7 input and output tokens. This is useful for debugging and for checking very-high-request-rates without taking a long time.
- Added an option to limit the number of in-flight requests. This is implemented straightforwardly with a bounded semaphore, limiting the number of calls to the backend request function (and therefore also the number of `aiohttp` sessions) that can execute concurrently. I have found this to be very useful in many cases, but especially for latency: often sending a single request is not realistic for measuring latency due to cold-start/warm-up issues, but sending requests with a small request rate does not guarantee it is only running one at a time and it can take a very long time if the server is faster than the request rate. By limiting the concurrent requests to 1 and sending with rate=inf, we can measure the latency "back-to-back" and average for a very good measure of requests per second. Limiting to other small numbers gives a good idea of the effects of batching on performance.
- Automatically download the ShareGPT dataset to `~/.cache/flexible_inference_bench/sharegpt.json` when "--dataset-name sharegpt" is given but "--dataset-path" is not. This has been quite helpful as I often have to re-download sharegpt on different machines when benchmarking, and it's hard to remember where to find the asset URL.

# Considerations

- **README.md** is still TODO. Once we have reviewed and finalized the CLI interface, I will update it before merging.
- I cannot guarantee that all these changes are backwards-compatible, and any existing infrastructure that depends on FIB should be tested before upgrading following a merge of these features.
- I have not tested this with TRT-LLM or any of the other backends, and while this won't break those use-cases, the convenience features are less likely to be effective.

This PR will close #73 and #75.

# Example Usage

#### Send a single request to a local vLLM or CServe server.
```
fib benchmark
```

#### Send 100 requests at once to a local vLLM or CServe server to measure throughput for RAG-like input/output lengths
```
fib benchmark -n 100 --rps inf -w rag
```

#### Measure the throughput of 100 requests to a CentML deployment, using the ShareGPT dataset
```
fib benchmark -n 100 --rps inf --dataset sharegpt --base-url https://example.abc123.centml.com
```

Result of llama-3.2-3B on 1xL4: 580 input tokens/second, 520 output tokens/second, 2.3 requests/second

#### Measure the single-request latency 100 times using a CentML deployment and the ShareGPT dataset
```
fib benchmark -n 100 --rps inf --dataset sharegpt --max-concurrent 1 --base-url https://example.abc123.centml.com
```

Result of llama-3.2-3B on 1xL4: 55 input tokens/second, 34 output tokens/second, 0.2 requests/second

