### PR TITLE
Accelerate ShareGPT prompt generation

### DIFF
--- a/src/flexible_inference_benchmark/engine/data.py
+++ b/src/flexible_inference_benchmark/engine/data.py
@@ -214,13 +214,18 @@ class ShareGPT(Data):
             dataset = json.load(f)
 
         dataset = [data for data in dataset if len(data["conversations"]) > 2]
+
+        sequences_to_encode = [data["conversations"][0]["value"] for data in dataset] + [
+            data["conversations"][1]["value"] for data in dataset
+        ]
+        results = tokenizer(sequences_to_encode)
         tokenized_dataset = [
             (
-                data["conversations"][0]["value"],
-                len(tokenizer(data["conversations"][0]["value"]).input_ids),
-                len(tokenizer(data["conversations"][1]["value"]).input_ids),
+                dataset[i]["conversations"][0]["value"],
+                len(results.input_ids[i]),
+                len(results.input_ids[i + len(dataset)]),
             )
-            for data in dataset
+            for i in range(len(dataset))
         ]
 
         filtered_dataset = [


### PR DESCRIPTION
Addresses #78 .

I suspected this block of code that calls tokenize(...) many times, so I timed it. For n=500 requests from sharegpt, it took 50 seconds. After this change, it takes 8.5 seconds.

All tests are passing locally. I validated the output by generating 500 requests using seed=0 for main and this branch, and all input prompts match and are in the right order.