### PR TITLE
Speed up ShareGPT startup time by caching tokenized lengths

### DIFF
--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -58,12 +58,12 @@ def generate_prompts(args: argparse.Namespace, tokenizer: AutoTokenizer, size: i
     if args.dataset_name.startswith('sharegpt'):
         logger.info(
             "User selected sharegpt dataset. "
-            "Ignoring prompt and output length distribution and following the shapes from the dataset.\n"
+            "Ignoring prompt and output length distribution and following the shapes from the dataset."
         )
         prompt_cls = ShareGPT(filename, tokenizer)
     else:
         logger.info(
-            f"User selected {args.dataset_name} dataset. Generating prompt and output lengths from distributions"
+            f"User selected {args.dataset_name} dataset. Generating prompt and output lengths from distributions."
         )
         input_prompt_dist = select_distribution(args.input_token_distribution)
         output_token_dist = select_distribution(args.output_token_distribution)
@@ -370,11 +370,13 @@ def run_main(args: argparse.Namespace) -> None:
     # disable verbose output for validation of the endpoint. This is done to avoid confusion on terminal output.
     client_verbose_value = client.verbose
     client.verbose = False
+    logger.info("Sending a single request for validation.")
     validate_endpoint = asyncio.run(client.validate_url_endpoint(requests_prompts[0]))
     if not validate_endpoint.success:
         logger.info(f"{validate_endpoint.error}.\nExiting benchmark ....")
         sys.exit()
     client.verbose = client_verbose_value
+    logger.info("Beginning benchmark.")
     t = time.perf_counter()
     output_list: List[Any] = send_requests(client, requests_prompts, requests_times)
     benchmark_time = time.perf_counter() - t


### PR DESCRIPTION
After doing a lot of benchmarking with FIB + sharegpt, the startup time seemed to still be an annoyance.

By caching the length of the tokenized sequences, we can avoid the costly encoding operation most of the time. Because this depends on the model's tokenizer, the cache is one-per-model. This shouldn't be a big issue in terms of space, as the cache is only a few MB (stored uncompressed) compared to sharegpt (>600MB, also uncompressed). If space becomes a concern we can store the cache more efficiently and also compress the sharegpt object on disk.

For now, this cuts down the startup time by about 6 seconds, and it now seems only slightly slow when it loads and parses the sharegpt json file.

Note: Also added some more verbose logging so the startup doesn't feel as sluggish