### PR TITLE
Add --logprobs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ After benchmarking, the results are saved to `output-file.json` (or specified by
 | `--disable-stream` | The requests are send with Stream: False. (Used for APIs without an stream option) |
 | `--cookies` | Include cookies in the request. |
 | `--config-file` | Path to configuration file. |
+| `--logprobs` | Number of logprobs to return with the request. FIB will not process them, but still useful for measuring the cost of computing / communicating logprobs. Defaults to None. |
 
 In addition to providing these arguments on the command-line, you can use `--config-file` to pre-define the parameters for your use case. Examples are provided in `examples/`
 

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -30,6 +30,7 @@ class RequestFuncInput(BaseModel):
     ignore_eos: bool = True
     stream: bool = True
     cookies: Dict[str, str]
+    logprobs: Optional[int] = None
 
 
 class RequestFuncOutput(BaseModel):
@@ -51,6 +52,7 @@ async def async_request_tgi(
 
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         assert not request_func_input.use_beam_search
+        assert request_func_input.logprobs is None
         params = {
             "best_of": request_func_input.best_of,
             "max_new_tokens": request_func_input.output_len,
@@ -120,6 +122,7 @@ async def async_request_trt_llm(
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         assert not request_func_input.use_beam_search
         assert request_func_input.best_of == 1
+        assert request_func_input.logprobs is None
         payload = {
             "accumulate_tokens": True,
             "text_input": request_func_input.prompt,
@@ -189,6 +192,7 @@ async def async_request_deepspeed_mii(
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         assert request_func_input.best_of == 1
         assert not request_func_input.use_beam_search
+        assert request_func_input.logprobs is None
 
         payload = {
             "prompt": request_func_input.prompt,
@@ -256,6 +260,8 @@ async def async_request_openai_completions(
                 "ignore_eos": request_func_input.ignore_eos,
                 "stream_options": {"include_usage": True},
             }
+            if request_func_input.logprobs is not None:
+                payload["logprobs"] = int(request_func_input.logprobs)
             headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
 
             output = RequestFuncOutput()
@@ -335,6 +341,8 @@ async def async_request_openai_completions(
                 "ignore_eos": request_func_input.ignore_eos,
                 "stream": False,
             }
+            if request_func_input.logprobs is not None:
+                payload["logprobs"] = int(request_func_input.logprobs)
             headers = {"Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
             output = RequestFuncOutput()
             output.prompt_len = request_func_input.prompt_len
@@ -392,6 +400,9 @@ async def async_request_openai_chat_completions(
             "stream": True,
             "ignore_eos": request_func_input.ignore_eos,
         }
+        if request_func_input.logprobs is not None:
+            payload["logprobs"] = True
+            payload["top_logprobs"] = int(request_func_input.logprobs)
         headers = {"Content-Type": "application/json", "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
 
         output = RequestFuncOutput()
@@ -465,6 +476,7 @@ async def async_request_cserve_debug(
     api_url = request_func_input.api_url
     assert api_url.endswith("v1/generate"), "CServe Completions API URL must end with 'v1/generate'."
     assert not request_func_input.use_beam_search
+    assert request_func_input.logprobs is None
 
     if request_func_input.stream:
         async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT, cookies=request_func_input.cookies) as session:

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -26,6 +26,7 @@ class Client:
         cookies: Dict[str, str],
         verbose: bool,
         max_concurrent: Optional[int],
+        logprobs: Optional[int],
     ):
         self.backend = backend
         self.api_url = api_url
@@ -39,6 +40,7 @@ class Client:
         self.cookies = cookies
         self.verbose = verbose
         self.max_concurrent = max_concurrent
+        self.logprobs = logprobs
 
     @property
     def request_func(
@@ -80,6 +82,7 @@ class Client:
                 ignore_eos=self.ignore_eos,
                 stream=self.stream,
                 cookies=self.cookies,
+                logprobs=self.logprobs,
             )
             for data_sample in data
         ]
@@ -106,5 +109,6 @@ class Client:
             ignore_eos=self.ignore_eos,
             stream=self.stream,
             cookies=self.cookies,
+            logprobs=self.logprobs,
         )
         return await self.send_request(0, data, 0, None, None)

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -158,6 +158,13 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> Any:  # t
     )
 
     benchmark_parser.add_argument(
+        "--logprobs",
+        type=int,
+        default=None,
+        help="Number of logprobs to return with each completion. Default is None, meaning no logprobs.",
+    )
+
+    benchmark_parser.add_argument(
         "--request-distribution",
         nargs="*",
         default=["exponential", 1],
@@ -366,6 +373,7 @@ def run_main(args: argparse.Namespace) -> None:
         args.cookies,
         args.verbose,
         args.max_concurrent,
+        args.logprobs,
     )
     # disable verbose output for validation of the endpoint. This is done to avoid confusion on terminal output.
     client_verbose_value = client.verbose


### PR DESCRIPTION
Allows for receiving logprobs with the request. The logprobs are not parsed in any way, and this is disclosed in the README. It's just for benchmarking requests where logprobs are computed and returned.