### PR TITLE
Add --wave argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After benchmarking, the results are saved to `output-file.json` (or specified by
 | `--max-concurrent` | Limits the number of concurrent in-flight requests to at most N requests. |
 | `--input-token-distribution` | Request distribution for prompt length. eg: <br> `uniform min_val max_val` <br> `normal mean std`. |
 | `--output-token-distribution` | Request distribution for output token length. eg: <br> `uniform min_val max_val` <br> `normal mean std`. |
-| `--varying-requests` (`--wave`) | Sends requests to maintain an oscillating request concurrency given min and max bounds and a wave intensity (1 to 100, lower means longer wave period, set to 50 if unsure). <br> eg: `--wave min_concurrency max_concurrency intensity` |
+| `--varying-requests` (`--wave`) | Sends requests to maintain an oscillating request concurrency given min, max, and sustain. <br> eg: `-n 400 --wave 10 30 20`, will send 400 requests with concurrency between 10 and 30 requests, sustaining for the duration of 20 requests at concurrency extrema. See [this graph](https://drive.google.com/file/d/1c0qrWa3DIEGxJdZO7hcKmehrPreBl84V/view?usp=sharing) for a visual. |
 | `--workload` (`-w`) | One of a few presets that define the input and output token distributions for common use-cases. |
 | one of:<br>`--prefix-text` or <br>`--prefix-len` | <br> Text to use as prefix for all requests. <br> Length of prefix to use for all requests. If neither are provided, no prefix is used. |
 | `--dataset-name` (`--dataset`) | Name of the dataset to benchmark on <br> {`sharegpt`,`other`,`random`}. |

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ After benchmarking, the results are saved to `output-file.json` (or specified by
 | one of <br> `--num-of-req` (`-n`) **or** <br> `--max-time-for-reqs` (`--timeout`) | <br> Total number of requests to send <br> time window for sending requests **(in seconds)** |
 | `--request-distribution` | Distribution for sending requests: <br> **eg:** `exponential 5` (request will follow an exponential distribution with an average time between requests of **5 seconds**) <br> options: <br> `poisson rate` <br> `uniform min_val max_val` <br> `normal mean std`. |
 | `--request-rate` (`-rps`) | Sets the request distribution to `poisson N`, such that approximately N requests are sent per second. |
+| `--max-concurrent` | Limits the number of concurrent in-flight requests to at most N requests. |
 | `--input-token-distribution` | Request distribution for prompt length. eg: <br> `uniform min_val max_val` <br> `normal mean std`. |
 | `--output-token-distribution` | Request distribution for output token length. eg: <br> `uniform min_val max_val` <br> `normal mean std`. |
+| `--varying-requests` (`--wave`) | Sends requests to maintain an oscillating request concurrency given min and max bounds and a wave intensity (1 to 100, lower means longer wave period, set to 50 if unsure). <br> eg: `--wave min_concurrency max_concurrency intensity` |
 | `--workload` (`-w`) | One of a few presets that define the input and output token distributions for common use-cases. |
 | one of:<br>`--prefix-text` or <br>`--prefix-len` | <br> Text to use as prefix for all requests. <br> Length of prefix to use for all requests. If neither are provided, no prefix is used. |
 | `--dataset-name` (`--dataset`) | Name of the dataset to benchmark on <br> {`sharegpt`,`other`,`random`}. |

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -96,7 +96,7 @@ class Client:
                 # If multiple requests finish before this is sent, the semaphore could have more capacity than wave_max
                 # So we acquire all to sync the semaphore with our expectation
                 while not sema.locked():
-                    sema.acquire()
+                    await sema.acquire()
 
         try:
             request_result = await self.send_request(idx, data, wait_time, pbar)

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -291,6 +291,10 @@ def parse_args() -> argparse.Namespace:
                 fail("Number of requests must be provided for varying requests")
             if args.wave[0] >= args.wave[1]:
                 fail("Min wave concurrency must be smaller than max wave concurrency")
+            if args.wave[0] <= 0:
+                fail("Min wave concurrency must be positive")
+            if args.wave[2] <= 0:
+                fail("Wave sustain must be positive")
             if args.max_concurrent:
                 logger.warning("Both varying requests and max concurrency provided. Ignoring max concurrency")
                 args.max_concurrent = None
@@ -388,8 +392,6 @@ def run_main(args: argparse.Namespace) -> None:
     base_url = args.base_url.strip("/")
     endpoint = args.endpoint.strip("/")
     args.api_url = f"{base_url}/{endpoint}"
-
-    logger.info(type(args.wave))
 
     client = Client(
         args.backend,

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -46,9 +46,13 @@ def generate_request_times(args: argparse.Namespace) -> List[Union[int, float]]:
         size = 1
         dist = select_distribution(args.request_distribution)
         # Check if any elements exceed max length
-        while not [i for i in dist.generate_distribution(size) if i > args.max_time_for_reqs]:
+        while size < 1e6 and not [i for i in dist.generate_distribution(size) if i > args.max_time_for_reqs]:
             size *= 2
         requests_times = dist.generate_distribution(size)
+        if size >= 1e6:
+            size = int(1e6)
+            # Eg. if the user runs `--timeout 10 -rps inf`, an arbitrary number of requests at time=0 can be generated
+            logger.warning("Capping number of requests at 1000`000")
         return [i for i in requests_times if i <= args.max_time_for_reqs]
 
 
@@ -193,6 +197,15 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> Any:  # t
         help="Request distribution [Distribution_type (inputs to distribution)]",
     )
 
+    benchmark_parser.add_argument(
+        "--varying-requests",
+        "--wave",
+        type=int,
+        nargs=3,
+        dest="wave",
+        help="Send requests at a varying request concurrency, increasing when the lowerbound rate is hit, and decreasing when the upperbound rate is hit",
+    )
+
     prefix_group = benchmark_parser.add_mutually_exclusive_group()
 
     prefix_group.add_argument("--prefix-text", type=str, default=None, help="Text to use as prefix for all requests.")
@@ -272,6 +285,22 @@ def parse_args() -> argparse.Namespace:
             print('\n\n\n')
             logger.error(msg)
             sys.exit(1)
+
+        if args.wave:
+            if not args.num_of_req:
+                fail("Number of requests must be provided for varying requests")
+            if args.wave[0] >= args.wave[1]:
+                fail("Min wave concurrency must be smaller than max wave concurrency")
+            if args.max_concurrent:
+                logger.warning("Both varying requests and max concurrency provided. Ignoring max concurrency")
+                args.max_concurrent = None
+            if args.request_distribution:
+                logger.warning(
+                    "Both varying requests and request rate/distribution provided. Ignoring request rate/distribution"
+                )
+                args.request_distribution = None
+
+            args.request_distribution = ["poisson", "inf"]
 
         if not (args.num_of_req or args.max_time_for_reqs):
             logger.info("Number of requests and max time for requests not provided. Defaulting to 1 request.")
@@ -360,6 +389,8 @@ def run_main(args: argparse.Namespace) -> None:
     endpoint = args.endpoint.strip("/")
     args.api_url = f"{base_url}/{endpoint}"
 
+    logger.info(type(args.wave))
+
     client = Client(
         args.backend,
         args.api_url,
@@ -373,6 +404,7 @@ def run_main(args: argparse.Namespace) -> None:
         args.cookies,
         args.verbose,
         args.max_concurrent,
+        args.wave,
         args.logprobs,
     )
     # disable verbose output for validation of the endpoint. This is done to avoid confusion on terminal output.

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -203,7 +203,7 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> Any:  # t
         type=int,
         nargs=3,
         dest="wave",
-        help="Send requests at a varying request concurrency, increasing when the lowerbound rate is hit, and decreasing when the upperbound rate is hit",
+        help="Send requests at a varying request concurrency in a wave-like pattern",
     )
 
     prefix_group = benchmark_parser.add_mutually_exclusive_group()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -35,6 +35,8 @@ def test_backend_function(vllm_server, args_config):
         not args.disable_stream,
         args.cookies,
         args.verbose,
+        None,
+        None,
         None
     )
 
@@ -88,6 +90,8 @@ def test_backend_function(vllm_server, args_config):
         not args.disable_stream,
         args.cookies,
         args.verbose,
+        None,
+        None,
         None
     )
 


### PR DESCRIPTION
Added functionality for --varying-requests (--wave). When this option is used, plotting the number of concurrent requests over time gives a wave-like graph, repeatedly increasing and decreasing. The option takes three required arguments in the order min_concurrency, max_concurrency, and sustain, with the first two being self descriptive and sustain being the number of requests to run while keeping the concurrency at min/max concurrency peaks. See [this image](https://drive.google.com/file/d/1c0qrWa3DIEGxJdZO7hcKmehrPreBl84V/view?usp=sharing) for a visualization.

Wave option was added to the README along with max-concurrent which was missing.

All existing unit tests pass
