### PR TITLE
[Bugfix] Use prompt_len and output_len from usage statistics in more backends

### DIFF
--- a/src/flexible_inference_benchmark/data_postprocessors/performance.py
+++ b/src/flexible_inference_benchmark/data_postprocessors/performance.py
@@ -30,7 +30,7 @@ def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, st
             else:
                 output_len = len(tokenizer(outputs[i]["generated_text"], add_special_tokens=False).input_ids)
             actual_output_lens.append(output_len)
-            total_input += input_requests[i][1]
+            total_input += outputs[i]["prompt_len"]
             if output_len > 1:
                 tpots.append((outputs[i]["latency"] - outputs[i]["ttft"]) / (output_len - 1))
             itls += outputs[i]["itl"]

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -290,7 +290,7 @@ async def async_request_openai_completions(
                             else:
                                 data = json.loads(chunk)
 
-                                if len(data["choices"]) > 0 and data["choices"][0]["text"]:
+                                if len(data["choices"]) > 0 and data["choices"][0]["text"] is not None:
                                     timestamp = time.perf_counter()
                                     # First token
                                     if ttft == 0.0:
@@ -308,7 +308,10 @@ async def async_request_openai_completions(
                                     generated_text += data["choices"][0]["text"]
 
                                 if data["usage"]:
-                                    output.output_len = data["usage"]["completion_tokens"]
+                                    if "completion_tokens" in data["usage"]:
+                                        output.output_len = int(data["usage"]["completion_tokens"])
+                                    if "prompt_tokens" in data["usage"]:
+                                        output.prompt_len = int(data["usage"]["prompt_tokens"])
 
                         output.generated_text = generated_text
                         output.success = True
@@ -363,6 +366,11 @@ async def async_request_openai_completions(
                         output.success = True
                         if verbose:
                             print_verbose(idx, request_func_input, 0, rcv_time, output.latency, False)
+                        if parsed_resp.get("usage", None):
+                            if "completion_tokens" in parsed_resp["usage"]:
+                                output.output_len = int(parsed_resp["usage"]["completion_tokens"])
+                            if "prompt_tokens" in parsed_resp["usage"]:
+                                output.prompt_len = int(parsed_resp["usage"]["prompt_tokens"])
                     else:
                         output.success = False
                         output.error = (
@@ -399,6 +407,7 @@ async def async_request_openai_chat_completions(
             "max_tokens": request_func_input.output_len,
             "stream": True,
             "ignore_eos": request_func_input.ignore_eos,
+            "stream_options": {"include_usage": True},
         }
         if request_func_input.logprobs is not None:
             payload["logprobs"] = True
@@ -431,8 +440,12 @@ async def async_request_openai_chat_completions(
                             timestamp = time.perf_counter()
                             data = json.loads(chunk)
 
-                            delta = data["choices"][0]["delta"]
-                            if delta.get("content", None):
+                            delta = data["choices"][0]["delta"] if len(data["choices"]) > 0 else None
+                            content = delta.get("content", None) if delta is not None else None
+                            # Make sure to include the content if it's not None
+                            # Since EOS can translate to an empty string, include `content == ""`
+                            # as long as it's not the first token
+                            if content is not None and not (ttft == 0.0 and content == ''):
                                 # First token
                                 if ttft == 0.0:
                                     ttft = time.perf_counter() - st
@@ -443,8 +456,13 @@ async def async_request_openai_chat_completions(
                                     output.itl.append(timestamp - most_recent_timestamp)
 
                                 generated_text += delta["content"]
+                                most_recent_timestamp = timestamp
 
-                            most_recent_timestamp = timestamp
+                            if "usage" in data:
+                                if data["usage"]["completion_tokens"]:
+                                    output.output_len = int(data["usage"]["completion_tokens"])
+                                if data["usage"]["prompt_tokens"]:
+                                    output.prompt_len = int(data["usage"]["prompt_tokens"])
 
                     output.generated_text = generated_text
                     output.success = True

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -35,6 +35,7 @@ def test_backend_function(vllm_server, args_config):
         not args.disable_stream,
         args.cookies,
         args.verbose,
+        None,
         None
     )
 
@@ -88,6 +89,7 @@ def test_backend_function(vllm_server, args_config):
         not args.disable_stream,
         args.cookies,
         args.verbose,
+        None,
         None
     )
 


### PR DESCRIPTION
The prompt_len and output_len from the server are most reliable in terms of token usage, as they include multimodal tokens and chat template tokens for the prompt, and they include all output tokens from the server. For speculative decoding multiple tokens can be batched in a single delta response, and for ignore-eos the deltas can have `"content": ""`. 

This PR expands support for these features, improving the reporting of ITLs, input token counts and output token counts. Also updated the analysis reporting to use the prompt length from the server, and fixed an existing bug in the tests.