### PR TITLE
Adding images to requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ After benchmarking, the results are saved to `output-file.json` (or specified by
 | `--input-token-distribution` | Request distribution for prompt length. eg: <br> `uniform min_val max_val` <br> `normal mean std`. |
 | `--output-token-distribution` | Request distribution for output token length. eg: <br> `uniform min_val max_val` <br> `normal mean std`. |
 | `--workload` (`-w`) | One of a few presets that define the input and output token distributions for common use-cases. |
+| `--num-of-imgs-per-req` | Number of images to attach to each request. Example: `3`. |
+| `--img-ratios-per-req` | Image aspect ratios (width x height) to attach per request. Example: `1000x1000`. Default: `500x500` |
+| `--img-base-path` | Base image directory. Example: `/path/to/imgs/`. If provided, images will be downloaded to this directory before benchmarking and fed from here. If not provided, images will be fed online, which could cause excessive network delays in large numbers. To enable this, the serving engine also needs to start with the `--allowed-local-media-path /path/to/imgs/` option. Default: `None`. |
 | one of:<br>`--prefix-text` or <br>`--prefix-len` | <br> Text to use as prefix for all requests. <br> Length of prefix to use for all requests. If neither are provided, no prefix is used. |
 | `--dataset-name` (`--dataset`) | Name of the dataset to benchmark on <br> {`sharegpt`,`other`,`random`}. |
 | `--dataset-path` | Path to the dataset. If `sharegpt` is the dataset and this is not provided, it will be automatically downloaded and cached. Otherwise, the dataset name will default to `other`. |

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -20,6 +20,7 @@ class bcolors:
 
 class RequestFuncInput(BaseModel):
     prompt: str
+    media: List[str]
     api_url: str
     prompt_len: int
     output_len: int
@@ -49,8 +50,7 @@ async def async_request_tgi(
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm],
     verbose: bool,
-    wait_time: float,
-    media: List[str]
+    wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
@@ -123,8 +123,7 @@ async def async_request_trt_llm(
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm],
     verbose: bool,
-    wait_time: float,
-    media: List[str]
+    wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
@@ -201,8 +200,7 @@ async def async_request_deepspeed_mii(
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm],
     verbose: bool,
-    wait_time: float,
-    media: List[str]
+    wait_time: float
 ) -> RequestFuncOutput:
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         assert request_func_input.best_of == 1
@@ -261,8 +259,7 @@ async def async_request_openai_completions(
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm],
     verbose: bool,
-    wait_time: float,
-    media: List[str]
+    wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("v1/completions"), "OpenAI Completions API URL must end with 'v1/completions'."
@@ -407,8 +404,7 @@ async def async_request_openai_chat_completions(
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm],
     verbose: bool,
-    wait_time: float,
-    media: List[str]
+    wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith(
@@ -422,7 +418,7 @@ async def async_request_openai_chat_completions(
         },
     ]
 
-    for media_item in media:
+    for media_item in request_func_input.media:
         content_body.append({
             "type": "image_url",
             "image_url": {
@@ -515,8 +511,7 @@ async def async_request_cserve_debug(
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm],
     verbose: bool,
-    wait_time: float,
-    media: List[str]
+    wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("v1/generate"), "CServe Completions API URL must end with 'v1/generate'."

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -391,20 +391,10 @@ async def async_request_openai_chat_completions(
         "v1/chat/completions"
     ), "OpenAI Chat Completions API URL must end with 'v1/chat/completions'."
 
-    content_body = [
-        {
-            "type": "text",
-            "text": request_func_input.prompt,
-        },
-    ]
+    content_body = [{"type": "text", "text": request_func_input.prompt}]
 
     for media_item in request_func_input.media:
-        content_body.append({
-            "type": "image_url",
-            "image_url": {
-                "url": media_item,
-            },
-        })
+        content_body.append({"type": "image_url", "image_url": {"url": media_item}})
 
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         assert not request_func_input.use_beam_search

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -44,17 +44,13 @@ class RequestFuncOutput(BaseModel):
     output_len: Optional[int] = None
 
 
-def return_random_image_URL_by_size(width=640, height=640):
-    return f"https://picsum.photos/{width}/{height}"
-
-
 async def async_request_tgi(
     idx: int,
     request_func_input: RequestFuncInput,
     pbar: Optional[tqdm],
     verbose: bool,
     wait_time: float,
-    media: List[Tuple[int, int]]
+    media: List[str]
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
@@ -128,7 +124,7 @@ async def async_request_trt_llm(
     pbar: Optional[tqdm],
     verbose: bool,
     wait_time: float,
-    media: List[Tuple[int, int]]
+    media: List[str]
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
@@ -206,7 +202,7 @@ async def async_request_deepspeed_mii(
     pbar: Optional[tqdm],
     verbose: bool,
     wait_time: float,
-    media: List[Tuple[int, int]]
+    media: List[str]
 ) -> RequestFuncOutput:
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         assert request_func_input.best_of == 1
@@ -266,7 +262,7 @@ async def async_request_openai_completions(
     pbar: Optional[tqdm],
     verbose: bool,
     wait_time: float,
-    media: List[Tuple[int, int]]
+    media: List[str]
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("v1/completions"), "OpenAI Completions API URL must end with 'v1/completions'."
@@ -412,7 +408,7 @@ async def async_request_openai_chat_completions(
     pbar: Optional[tqdm],
     verbose: bool,
     wait_time: float,
-    media: List[Tuple[int, int]]
+    media: List[str]
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith(
@@ -430,7 +426,7 @@ async def async_request_openai_chat_completions(
         content_body.append({
             "type": "image_url",
             "image_url": {
-                "url": return_random_image_URL_by_size(media_item[0], media_item[1]),
+                "url": media_item,
             },
         })
 
@@ -520,7 +516,7 @@ async def async_request_cserve_debug(
     pbar: Optional[tqdm],
     verbose: bool,
     wait_time: float,
-    media: List[Tuple[int, int]]
+    media: List[str]
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("v1/generate"), "CServe Completions API URL must end with 'v1/generate'."

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -46,11 +46,7 @@ class RequestFuncOutput(BaseModel):
 
 
 async def async_request_tgi(
-    idx: int,
-    request_func_input: RequestFuncInput,
-    pbar: Optional[tqdm],
-    verbose: bool,
-    wait_time: float
+    idx: int, request_func_input: RequestFuncInput, pbar: Optional[tqdm], verbose: bool, wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
@@ -119,11 +115,7 @@ async def async_request_tgi(
 
 
 async def async_request_trt_llm(
-    idx: int,
-    request_func_input: RequestFuncInput,
-    pbar: Optional[tqdm],
-    verbose: bool,
-    wait_time: float
+    idx: int, request_func_input: RequestFuncInput, pbar: Optional[tqdm], verbose: bool, wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("generate_stream")
@@ -196,11 +188,7 @@ async def async_request_trt_llm(
 
 
 async def async_request_deepspeed_mii(
-    idx: int,
-    request_func_input: RequestFuncInput,
-    pbar: Optional[tqdm],
-    verbose: bool,
-    wait_time: float
+    idx: int, request_func_input: RequestFuncInput, pbar: Optional[tqdm], verbose: bool, wait_time: float
 ) -> RequestFuncOutput:
     async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
         assert request_func_input.best_of == 1
@@ -255,11 +243,7 @@ async def async_request_deepspeed_mii(
 
 
 async def async_request_openai_completions(
-    idx: int,
-    request_func_input: RequestFuncInput,
-    pbar: Optional[tqdm],
-    verbose: bool,
-    wait_time: float
+    idx: int, request_func_input: RequestFuncInput, pbar: Optional[tqdm], verbose: bool, wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("v1/completions"), "OpenAI Completions API URL must end with 'v1/completions'."
@@ -400,11 +384,7 @@ async def async_request_openai_completions(
 
 
 async def async_request_openai_chat_completions(
-    idx: int,
-    request_func_input: RequestFuncInput,
-    pbar: Optional[tqdm],
-    verbose: bool,
-    wait_time: float
+    idx: int, request_func_input: RequestFuncInput, pbar: Optional[tqdm], verbose: bool, wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith(
@@ -507,11 +487,7 @@ async def async_request_openai_chat_completions(
 
 
 async def async_request_cserve_debug(
-    idx: int,
-    request_func_input: RequestFuncInput,
-    pbar: Optional[tqdm],
-    verbose: bool,
-    wait_time: float
+    idx: int, request_func_input: RequestFuncInput, pbar: Optional[tqdm], verbose: bool, wait_time: float
 ) -> RequestFuncOutput:
     api_url = request_func_input.api_url
     assert api_url.endswith("v1/generate"), "CServe Completions API URL must end with 'v1/generate'."

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -54,7 +54,6 @@ class Client:
         idx: int,
         data: RequestFuncInput,
         wait_time: float,
-        request_media: List[str],
         pbar: Optional[tqdm],
         sema: Optional[asyncio.BoundedSemaphore],
     ) -> Optional[Union[RequestFuncOutput, Any]]:
@@ -62,10 +61,10 @@ class Client:
         if sema:
             async with sema:
                 return await self.request_func(idx, data, pbar, self.verbose, \
-                                               wait_time, request_media)
+                                               wait_time)
         else:
             return await self.request_func(idx, data, pbar, self.verbose, \
-                                           wait_time, request_media)
+                                           wait_time)
 
     async def benchmark(
         self,
@@ -80,6 +79,7 @@ class Client:
         request_func_inputs = [
             RequestFuncInput(
                 prompt=data_sample[0],
+                media=media_sample,
                 api_url=self.api_url,
                 prompt_len=data_sample[1],
                 output_len=data_sample[2],
@@ -92,22 +92,23 @@ class Client:
                 cookies=self.cookies,
                 logprobs=self.logprobs,
             )
-            for data_sample in data
+            for (data_sample, media_sample) in zip(data, requests_media)
         ]
 
         sema = asyncio.BoundedSemaphore(self.max_concurrent) if self.max_concurrent else None
 
         return await asyncio.gather(
             *[
-                self.send_request(idx, data, request_time, request_media, pbar, sema)
-                for idx, (data, request_time, request_media) in enumerate(
-                    zip(request_func_inputs, request_times, requests_media))
+                self.send_request(idx, data, request_time, pbar, sema)
+                for idx, (data, request_time) in enumerate(
+                    zip(request_func_inputs, request_times))
             ]
         )
 
-    async def validate_url_endpoint(self, request: Tuple[str, int, int]) -> Union[RequestFuncOutput, Any]:
+    async def validate_url_endpoint(self, request: Tuple[str, int, int], media_item: List[str]) -> Union[RequestFuncOutput, Any]:
         data = RequestFuncInput(
             prompt=request[0],
+            media=media_item,
             api_url=self.api_url,
             prompt_len=request[1],
             output_len=request[2],
@@ -120,4 +121,4 @@ class Client:
             cookies=self.cookies,
             logprobs=self.logprobs,
         )
-        return await self.send_request(0, data, 0, [], None, None)
+        return await self.send_request(0, data, 0, None, None)

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -45,7 +45,7 @@ class Client:
     @property
     def request_func(
         self,
-    ) -> Callable[[int, RequestFuncInput, Any, bool, float, List[Tuple[int, int]]], \
+    ) -> Callable[[int, RequestFuncInput, Any, bool, float, List[str]], \
                   Coroutine[Any, Any, RequestFuncOutput]]:
         return ASYNC_REQUEST_FUNCS[self.backend]
 
@@ -54,7 +54,7 @@ class Client:
         idx: int,
         data: RequestFuncInput,
         wait_time: float,
-        request_media: List[Tuple[int, int]],
+        request_media: List[str],
         pbar: Optional[tqdm],
         sema: Optional[asyncio.BoundedSemaphore],
     ) -> Optional[Union[RequestFuncOutput, Any]]:
@@ -71,7 +71,7 @@ class Client:
         self,
         data: List[Tuple[str, int, int]],
         request_times: List[Union[float, int]],
-        requests_media: List[List[Tuple[int, int]]]
+        requests_media: List[List[str]]
     ) -> list[Union[RequestFuncOutput, Any, None]]:
         assert len(data) == len(request_times), "Data and request times must have the same length"
         assert len(data) == len(requests_media), "Data and request media must have the same length"

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -45,8 +45,7 @@ class Client:
     @property
     def request_func(
         self,
-    ) -> Callable[[int, RequestFuncInput, Any, bool, float, List[str]], \
-                  Coroutine[Any, Any, RequestFuncOutput]]:
+    ) -> Callable[[int, RequestFuncInput, Any, bool, float], Coroutine[Any, Any, RequestFuncOutput]]:
         return ASYNC_REQUEST_FUNCS[self.backend]
 
     async def send_request(
@@ -60,11 +59,9 @@ class Client:
         await asyncio.sleep(wait_time)
         if sema:
             async with sema:
-                return await self.request_func(idx, data, pbar, self.verbose, \
-                                               wait_time)
+                return await self.request_func(idx, data, pbar, self.verbose, wait_time)
         else:
-            return await self.request_func(idx, data, pbar, self.verbose, \
-                                           wait_time)
+            return await self.request_func(idx, data, pbar, self.verbose, wait_time)
 
     async def benchmark(
         self,
@@ -100,8 +97,7 @@ class Client:
         return await asyncio.gather(
             *[
                 self.send_request(idx, data, request_time, pbar, sema)
-                for idx, (data, request_time) in enumerate(
-                    zip(request_func_inputs, request_times))
+                for idx, (data, request_time) in enumerate(zip(request_func_inputs, request_times))
             ]
         )
 

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -64,10 +64,7 @@ class Client:
             return await self.request_func(idx, data, pbar, self.verbose, wait_time)
 
     async def benchmark(
-        self,
-        data: List[Tuple[str, int, int]],
-        request_times: List[Union[float, int]],
-        requests_media: List[List[str]]
+        self, data: List[Tuple[str, int, int]], request_times: List[Union[float, int]], requests_media: List[List[str]]
     ) -> list[Union[RequestFuncOutput, Any, None]]:
         assert len(data) == len(request_times), "Data and request times must have the same length"
         assert len(data) == len(requests_media), "Data and request media must have the same length"
@@ -101,7 +98,9 @@ class Client:
             ]
         )
 
-    async def validate_url_endpoint(self, request: Tuple[str, int, int], media_item: List[str]) -> Union[RequestFuncOutput, Any]:
+    async def validate_url_endpoint(
+        self, request: Tuple[str, int, int], media_item: List[str]
+    ) -> Union[RequestFuncOutput, Any]:
         data = RequestFuncInput(
             prompt=request[0],
             media=media_item,

--- a/src/flexible_inference_benchmark/engine/data.py
+++ b/src/flexible_inference_benchmark/engine/data.py
@@ -164,7 +164,7 @@ class Random(Data):
         tokenizer: transformers.PreTrainedTokenizer,
         num_trials: int = 10,
     ) -> "Random":
-        token_distribution = distributions.UniformInt(0, len(tokenizer.get_vocab()))
+        token_distribution = distributions.UniformInt(0, 10000) # len(tokenizer.get_vocab())) ## Specifying a fixed range
 
         return cls(
             prefix_str, prefill_distribution, token_distribution, output_token_distribution, tokenizer, num_trials

--- a/src/flexible_inference_benchmark/engine/data.py
+++ b/src/flexible_inference_benchmark/engine/data.py
@@ -164,8 +164,8 @@ class Random(Data):
         tokenizer: transformers.PreTrainedTokenizer,
         num_trials: int = 10,
     ) -> "Random":
-        ## Specifying a fixed range to avoid accidental generation of <image> tokens
-        token_distribution = distributions.UniformInt(0, 10000) # len(tokenizer.get_vocab()))
+        ## Specifying the middle 50% range to avoid accidental generation of <image> tokens
+        token_distribution = distributions.UniformInt(len(tokenizer.get_vocab()) // 4, 3 * len(tokenizer.get_vocab()) // 4)
 
         return cls(
             prefix_str, prefill_distribution, token_distribution, output_token_distribution, tokenizer, num_trials

--- a/src/flexible_inference_benchmark/engine/data.py
+++ b/src/flexible_inference_benchmark/engine/data.py
@@ -164,7 +164,8 @@ class Random(Data):
         tokenizer: transformers.PreTrainedTokenizer,
         num_trials: int = 10,
     ) -> "Random":
-        token_distribution = distributions.UniformInt(0, 10000) # len(tokenizer.get_vocab())) ## Specifying a fixed range
+        ## Specifying a fixed range to avoid accidental generation of <image> tokens
+        token_distribution = distributions.UniformInt(0, 10000) # len(tokenizer.get_vocab()))
 
         return cls(
             prefix_str, prefill_distribution, token_distribution, output_token_distribution, tokenizer, num_trials

--- a/src/flexible_inference_benchmark/engine/data.py
+++ b/src/flexible_inference_benchmark/engine/data.py
@@ -165,7 +165,9 @@ class Random(Data):
         num_trials: int = 10,
     ) -> "Random":
         ## Specifying the middle 50% range to avoid accidental generation of <image> tokens
-        token_distribution = distributions.UniformInt(len(tokenizer.get_vocab()) // 4, 3 * len(tokenizer.get_vocab()) // 4)
+        token_distribution = distributions.UniformInt(
+            len(tokenizer.get_vocab()) // 4, 3 * len(tokenizer.get_vocab()) // 4
+        )
 
         return cls(
             prefix_str, prefill_distribution, token_distribution, output_token_distribution, tokenizer, num_trials

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -366,7 +366,7 @@ def parse_args() -> argparse.Namespace:
         if not args.base_url or not args.model or not args.endpoint:
             if not args.base_url:
                 logger.info("Base url not provided. Searching for ports on localhost...")
-                base_try_options = ["http://localhost:8000", "http://localhost:8080", "http://localhost:8081"]
+                base_try_options = ["http://localhost:8000", "http://localhost:8080"]
             else:
                 base_try_options = [args.base_url]
             for base_url, path in itertools.product(base_try_options, ["openapi.json", "health", "openai/health"]):

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -466,7 +466,7 @@ def run_main(args: argparse.Namespace) -> None:
     client_verbose_value = client.verbose
     client.verbose = False
     logger.info("Sending a single request for validation.")
-    validate_endpoint = asyncio.run(client.validate_url_endpoint(requests_prompts[0]))
+    validate_endpoint = asyncio.run(client.validate_url_endpoint(requests_prompts[0], requests_media[0]))
     if not validate_endpoint.success:
         logger.info(f"{validate_endpoint.error}.\nExiting benchmark ....")
         sys.exit()

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -37,7 +37,7 @@ def return_random_image_URL_by_size(width, height):
 def parse_tuple(value):
     """
     Parses a width-height pair into a tuple of ints.
-    
+
     Example:
         "1280x720" -> (1280, 720)
     """
@@ -50,8 +50,7 @@ def parse_tuple(value):
 
 
 # Specify the number and dimensions of images to be attached to each request
-def generate_request_media(args: argparse.Namespace, size) \
-    -> Union[List[List[Union[Tuple[int, int], str]]], None]:
+def generate_request_media(args: argparse.Namespace, size) -> Union[List[List[Union[Tuple[int, int], str]]], None]:
 
     num_imgs_per_req = args.num_of_imgs_per_req
     if not num_imgs_per_req:
@@ -80,7 +79,7 @@ def generate_request_media(args: argparse.Namespace, size) \
                 # Fetch the image online with the ratios
                 media_per_request[-1].append(return_random_image_URL_by_size(ratios[0], ratios[1]))
             img_cntr += 1
-    
+
     return media_per_request
 
 
@@ -211,23 +210,23 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> Any:  # t
         "--num-of-imgs-per-req",
         type=int,
         default=None,
-        help="Number of images to attach to each request. Example: '3'."
+        help="Number of images to attach to each request. Example: '3'.",
     )
 
     benchmark_parser.add_argument(
         "--img-ratios-per-req",
         type=parse_tuple,
         default='500x500',
-        help="Image aspect ratios (width x height) to attach per request. Example: '500x500'."
+        help="Image aspect ratios (width x height) to attach per request. Example: '500x500'.",
     )
 
     benchmark_parser.add_argument(
         "--img-base-path",
         type=str,
         default=None,
-        help="Base image directory. Example: '/path/to/imgs/'. If provided, images will be downloaded to" \
-        " this directory before benchmarking and fed from here. If not provided, images will be fed online," \
-        " which could cause excessive network delays in large numbers. To enable this, the serving engine" \
+        help="Base image directory. Example: '/path/to/imgs/'. If provided, images will be downloaded to"
+        " this directory before benchmarking and fed from here. If not provided, images will be fed online,"
+        " which could cause excessive network delays in large numbers. To enable this, the serving engine"
         " also needs to start with the --allowed-local-media-path /path/to/imgs/ option.",
     )
 


### PR DESCRIPTION
This PR incorporates images to requests using the three options:
```
    benchmark_parser.add_argument(
        "--num-of-imgs-per-req",
        type=int,
        default=None,
        help="Number of images to attach to each request. Example: '3'."
    )

    benchmark_parser.add_argument(
        "--img-ratios-per-req",
        type=parse_tuple,
        default='500x500',
        help="Image aspect ratios (width x height) to attach per request. Example: '500x500'."
    )

    benchmark_parser.add_argument(
        "--img-base-path",
        type=str,
        default=None,
        help="Base image directory. Example: '/path/to/imgs/'",
    )
```