### PR TITLE
[Patch] Include reasoning content for ttft

### DIFF
--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -455,7 +455,7 @@ async def async_request_openai_chat_completions(
                             if (
                                 content is not None
                                 or reasoning_content is not None
-                                and not (ttft == 0.0 and content == '' and reasoning_content == '')
+                                and not (ttft == 0.0 and (content == '' or reasoning_content == ''))
                             ):
                                 # First token
                                 if ttft == 0.0:
@@ -466,9 +466,9 @@ async def async_request_openai_chat_completions(
                                 else:
                                     output.itl.append(timestamp - most_recent_timestamp)
                                 if content:
-                                    generated_text += delta["content"]
+                                    generated_text += content
                                 elif reasoning_content:
-                                    generated_text += delta["reasoning_content"]
+                                    generated_text += reasoning_content
                                 most_recent_timestamp = timestamp
 
                             if "usage" in data:

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -453,8 +453,8 @@ async def async_request_openai_chat_completions(
                             # Since EOS can translate to an empty string, include `content == ""`
                             # as long as it's not the first token
                             if (
-                                content is not None
-                                or reasoning_content is not None
+                                (content is not None
+                                or reasoning_content is not None)
                                 and not (ttft == 0.0 and (content == '' or reasoning_content == ''))
                             ):
                                 # First token

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -448,10 +448,15 @@ async def async_request_openai_chat_completions(
 
                             delta = data["choices"][0]["delta"] if len(data["choices"]) > 0 else None
                             content = delta.get("content", None) if delta is not None else None
+                            reasoning_content = delta.get("reasoning_content", None) if delta is not None else None
                             # Make sure to include the content if it's not None
                             # Since EOS can translate to an empty string, include `content == ""`
                             # as long as it's not the first token
-                            if content is not None and not (ttft == 0.0 and content == ''):
+                            if (
+                                content is not None
+                                or reasoning_content is not None
+                                and not (ttft == 0.0 and content == '' and reasoning_content == '')
+                            ):
                                 # First token
                                 if ttft == 0.0:
                                     ttft = time.perf_counter() - st
@@ -460,8 +465,10 @@ async def async_request_openai_chat_completions(
                                 # Decoding phase
                                 else:
                                     output.itl.append(timestamp - most_recent_timestamp)
-
-                                generated_text += delta["content"]
+                                if content:
+                                    generated_text += delta["content"]
+                                elif reasoning_content:
+                                    generated_text += delta["reasoning_content"]
                                 most_recent_timestamp = timestamp
 
                             if "usage" in data:


### PR DESCRIPTION
include reasoning_content in chat completions:
Incoming responses come as:
```
data: {"id":"chatcmpl-ddbe3185e2164fe788c0e2ed495489a0","object":"chat.completion.chunk","created":1744916428,"model":"Qwen/QwQ-32B","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}]}

data: {"id":"chatcmpl-ddbe3185e2164fe788c0e2ed495489a0","object":"chat.completion.chunk","created":1744916428,"model":"Qwen/QwQ-32B","choices":[{"index":0,"delta":{"reasoning_content":"Okay"},"logprobs":null,"finish_reason":null}]}
```
ttft will be counted from reasoning_content