### PR TITLE
[FLAG] Ignore input distribution

### DIFF
--- a/src/flexible_inference_benchmark/engine/data.py
+++ b/src/flexible_inference_benchmark/engine/data.py
@@ -136,10 +136,10 @@ class Textfile(Data):
         starts = self.start_distribution.generate_distribution(lengths)
         prefix_len = len(self.tokenizer.encode(self.prefix_str))
 
-        for i in range(size):
-            if self.ignore_input_distribution:
-                input_data.append([self.prefix_str, prefix_len, output_tokens[i]])
-            else:
+        if self.ignore_input_distribution:
+            input_data = [[self.prefix_str, prefix_len, output_tokens[i]] for i in range(size)]
+        else:
+            for i in range(size):
                 if lengths[i] - prefix_len < 0:  # skip when sampling length less than prefix
                     continue
                 prompt_end = get_data_end(
@@ -154,9 +154,11 @@ class Textfile(Data):
                         output_tokens[i],
                     )
                 )
+
         if len(input_data) < size:
             logger.debug(f"Generating {len(input_data)} requests instead of {size} requests.")
             return input_data
+
         return random.sample(input_data, size)
 
 
@@ -235,10 +237,10 @@ class Random(Data):
         output_tokens = self.output_token_distribution.generate_distribution(size)
         prefix_len = len(self.tokenizer.encode(self.prefix_str))
 
-        for i in range(size):
-            if self.ignore_input_distribution:
-                input_data.append([self.prefix_str, prefix_len, output_tokens[i]])
-            else:
+        if self.ignore_input_distribution:
+            input_data = [[self.prefix_str, prefix_len, output_tokens[i]] for i in range(size)]
+        else:
+            for i in range(size):
                 data = list(self.token_distribution.generate_distribution(lengths[i] + self.num_trials))
                 if lengths[i] - prefix_len < 0:  # skip when sampling length less than prefix
                     continue

--- a/src/flexible_inference_benchmark/engine/data.py
+++ b/src/flexible_inference_benchmark/engine/data.py
@@ -60,6 +60,7 @@ class Textfile(Data):
         output_token_distribution: distributions.Distribution,
         tokenizer: transformers.PreTrainedTokenizer,
         num_trials: int,
+        ignore_input_distribution: bool,
     ) -> None:
         self.prefix_str = prefix_str
         self.prefill_distribution = prefill_distribution
@@ -68,6 +69,7 @@ class Textfile(Data):
         self.tokenizer = tokenizer
         self.data = data
         self.num_trials = num_trials
+        self.ignore_input_distribution = ignore_input_distribution
 
     @classmethod
     def with_prefix_str(
@@ -77,13 +79,22 @@ class Textfile(Data):
         prefill_distribution: distributions.Distribution,
         output_token_distribution: distributions.Distribution,
         tokenizer: transformers.PreTrainedTokenizer,
+        ignore_input_distribution: bool,
         num_trials: int = 10,
     ) -> "Textfile":
         with open(filename) as f:
             text = f.read()
         data = tokenizer.encode(text)
 
-        return cls(data, prefix_str, prefill_distribution, output_token_distribution, tokenizer, num_trials)
+        return cls(
+            data,
+            prefix_str,
+            prefill_distribution,
+            output_token_distribution,
+            tokenizer,
+            num_trials,
+            ignore_input_distribution,
+        )
 
     @classmethod
     def with_prefix_len(
@@ -93,6 +104,7 @@ class Textfile(Data):
         prefill_distribution: distributions.Distribution,
         output_token_distribution: distributions.Distribution,
         tokenizer: transformers.PreTrainedTokenizer,
+        ignore_input_distribution: bool,
         num_trials: int = 10,
     ) -> "Textfile":
         with open(filename) as f:
@@ -107,7 +119,13 @@ class Textfile(Data):
         prefix_str = tokenizer.decode(data[:prefix_end]) if prefix_end > 0 else ""
 
         return cls(
-            data[prefix_end:], prefix_str, prefill_distribution, output_token_distribution, tokenizer, num_trials
+            data[prefix_end:],
+            prefix_str,
+            prefill_distribution,
+            output_token_distribution,
+            tokenizer,
+            num_trials,
+            ignore_input_distribution,
         )
 
     def generate_data(self, size: int) -> List[Tuple[str, int, int]]:
@@ -119,19 +137,23 @@ class Textfile(Data):
         prefix_len = len(self.tokenizer.encode(self.prefix_str))
 
         for i in range(size):
-            if lengths[i] - prefix_len < 0:  # skip when sampling length less than prefix
-                continue
-            prompt_end = get_data_end(self.data, self.tokenizer, starts[i], lengths[i] - prefix_len, self.num_trials)
-            achieved_len = (prompt_end - starts[i]) + prefix_len
-
-            input_data.append(
-                (
-                    self.prefix_str + self.tokenizer.decode(self.data[starts[i] : prompt_end]),
-                    achieved_len,
-                    output_tokens[i],
+            if self.ignore_input_distribution:
+                input_data.append([self.prefix_str, prefix_len, output_tokens[i]])
+            else:
+                if lengths[i] - prefix_len < 0:  # skip when sampling length less than prefix
+                    continue
+                prompt_end = get_data_end(
+                    self.data, self.tokenizer, starts[i], lengths[i] - prefix_len, self.num_trials
                 )
-            )
+                achieved_len = (prompt_end - starts[i]) + prefix_len
 
+                input_data.append(
+                    (
+                        self.prefix_str + self.tokenizer.decode(self.data[starts[i] : prompt_end]),
+                        achieved_len,
+                        output_tokens[i],
+                    )
+                )
         if len(input_data) < size:
             logger.debug(f"Generating {len(input_data)} requests instead of {size} requests.")
             return input_data
@@ -147,6 +169,7 @@ class Random(Data):
         output_token_distribution: distributions.Distribution,
         tokenizer: transformers.PreTrainedTokenizer,
         num_trials: int,
+        ignore_input_distribution: bool,
     ) -> None:
         self.tokenizer = tokenizer
         self.prefill_distribution = prefill_distribution
@@ -154,6 +177,7 @@ class Random(Data):
         self.output_token_distribution = output_token_distribution
         self.prefix_str = prefix_str
         self.num_trials = num_trials
+        self.ignore_input_distribution = ignore_input_distribution
 
     @classmethod
     def with_prefix_str(
@@ -162,6 +186,7 @@ class Random(Data):
         prefill_distribution: distributions.Distribution,
         output_token_distribution: distributions.Distribution,
         tokenizer: transformers.PreTrainedTokenizer,
+        ignore_input_distribution: bool,
         num_trials: int = 10,
     ) -> "Random":
         ## Specifying the middle 50% range to avoid accidental generation of <image> tokens
@@ -170,7 +195,13 @@ class Random(Data):
         )
 
         return cls(
-            prefix_str, prefill_distribution, token_distribution, output_token_distribution, tokenizer, num_trials
+            prefix_str,
+            prefill_distribution,
+            token_distribution,
+            output_token_distribution,
+            tokenizer,
+            num_trials,
+            ignore_input_distribution,
         )
 
     @classmethod
@@ -180,6 +211,7 @@ class Random(Data):
         prefill_distribution: distributions.Distribution,
         output_token_distribution: distributions.Distribution,
         tokenizer: transformers.PreTrainedTokenizer,
+        ignore_input_distribution: bool,
         num_trials: int = 10,
     ) -> "Random":
         token_distribution = distributions.UniformInt(0, len(tokenizer.get_vocab()))
@@ -188,7 +220,13 @@ class Random(Data):
         prefix_str = tokenizer.decode(data[:prefix_end]) if prefix_end > 0 else ""
 
         return cls(
-            prefix_str, prefill_distribution, token_distribution, output_token_distribution, tokenizer, num_trials
+            prefix_str,
+            prefill_distribution,
+            token_distribution,
+            output_token_distribution,
+            tokenizer,
+            num_trials,
+            ignore_input_distribution,
         )
 
     def generate_data(self, size: int) -> List[Tuple[str, int, int]]:
@@ -198,15 +236,18 @@ class Random(Data):
         prefix_len = len(self.tokenizer.encode(self.prefix_str))
 
         for i in range(size):
-            data = list(self.token_distribution.generate_distribution(lengths[i] + self.num_trials))
-            if lengths[i] - prefix_len < 0:  # skip when sampling length less than prefix
-                continue
-            prompt_end = get_data_end(data, self.tokenizer, 0, lengths[i] - prefix_len, self.num_trials)
-            achieved_len = prompt_end + prefix_len
+            if self.ignore_input_distribution:
+                input_data.append([self.prefix_str, prefix_len, output_tokens[i]])
+            else:
+                data = list(self.token_distribution.generate_distribution(lengths[i] + self.num_trials))
+                if lengths[i] - prefix_len < 0:  # skip when sampling length less than prefix
+                    continue
+                prompt_end = get_data_end(data, self.tokenizer, 0, lengths[i] - prefix_len, self.num_trials)
+                achieved_len = prompt_end + prefix_len
 
-            input_data.append(
-                (self.prefix_str + self.tokenizer.decode(data[:prompt_end]), achieved_len, output_tokens[i])
-            )
+                input_data.append(
+                    (self.prefix_str + self.tokenizer.decode(data[:prompt_end]), achieved_len, output_tokens[i])
+                )
 
         if len(input_data) < size:
             logger.debug(f"Generating {len(input_data)} requests instead of {size} requests.")

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -289,7 +289,7 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> Any:  # t
     benchmark_parser.add_argument(
         "--ignore-input-distribution",
         action="store_true",
-        help="Use prefix only for input and ignore the input token distribution",
+        help="Ignore the input token distribution. This is meant to be used with --prefix-len or --prefix-text.",
     )
 
     benchmark_parser.add_argument(

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -127,18 +127,34 @@ def generate_prompts(args: argparse.Namespace, tokenizer: AutoTokenizer, size: i
 
         if args.prefix_len:
             prompt_cls = (
-                Random.with_prefix_len(args.prefix_len, input_prompt_dist, output_token_dist, tokenizer)
+                Random.with_prefix_len(
+                    args.prefix_len, input_prompt_dist, output_token_dist, tokenizer, args.ignore_input_distribution
+                )
                 if args.dataset_name == "random"
                 else Textfile.with_prefix_len(
-                    filename, args.prefix_len, input_prompt_dist, output_token_dist, tokenizer
+                    filename,
+                    args.prefix_len,
+                    input_prompt_dist,
+                    output_token_dist,
+                    tokenizer,
+                    args.ignore_input_distribution,
                 )
             )
         else:
             prefix_text = args.prefix_text or ""
             prompt_cls = (
-                Random.with_prefix_str(prefix_text, input_prompt_dist, output_token_dist, tokenizer)
+                Random.with_prefix_str(
+                    prefix_text, input_prompt_dist, output_token_dist, tokenizer, args.ignore_input_distribution
+                )
                 if args.dataset_name == "random"
-                else Textfile.with_prefix_str(filename, prefix_text, input_prompt_dist, output_token_dist, tokenizer)
+                else Textfile.with_prefix_str(
+                    filename,
+                    prefix_text,
+                    input_prompt_dist,
+                    output_token_dist,
+                    tokenizer,
+                    args.ignore_input_distribution,
+                )
             )
 
     if not prompt_cls:
@@ -268,6 +284,12 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> Any:  # t
         nargs="*",
         default=["uniform", 1, 255],
         help="Request distribution [Distribution_type (inputs to distribution)]",
+    )
+
+    benchmark_parser.add_argument(
+        "--ignore-input-distribution",
+        action="store_true",
+        help="Use prefix only for input and ignore the input token distribution",
     )
 
     benchmark_parser.add_argument(


### PR DESCRIPTION
This PR is to handle a special case for prefix length or prefix text.
When we enable prefix text or length, fib will try to fill the input length depending on the distribution. Sometimes we may not want that to happen. For example, for vision test our prompt would be "Please describe the image, and indicate as many details as possible" but we do not want any extra characters. I added the flag ```--ignore-input-distribution``` to avoid this.