### PR TITLE
[Feat] Add audio benchmarking support `/v1/audio/transcriptions`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ dependencies = [
     "sentencepiece",
     "aiohttp",
     "pydantic",
-    "matplotlib"
+    "matplotlib",
+    "librosa",
+    "soundfile",
+    "datasets",
 ]
 
 classifiers = [
@@ -23,6 +26,8 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 
 [tool.setuptools]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,3 +17,8 @@ aiohttp
 openai
 httpx
 vllm
+
+# audio
+librosa
+soundfile
+datasets

--- a/src/flexible_inference_benchmark/engine/data.py
+++ b/src/flexible_inference_benchmark/engine/data.py
@@ -1,12 +1,18 @@
 # pylint: disable=too-many-positional-arguments
 import abc
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 import logging
 import json
 import random
 import os
+import tempfile
+import shutil
+import numpy as np
 from hashlib import sha256
 
+import librosa
+import soundfile
+from datasets import load_dataset  # type: ignore[attr-defined]
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase  # type: ignore[attr-defined]
 from flexible_inference_benchmark.engine import distributions
 
@@ -254,6 +260,169 @@ class Random(Data):
             logger.debug(f"Generating {len(input_data)} requests instead of {size} requests.")
             return input_data
         return random.sample(input_data, size)
+
+
+class ASRDataset(Data):
+    """
+    Dataset class for loading and preparing audio data for ASR benchmarking.
+    Originally inspired from vLLM's ASR dataset class.
+    
+    This class loads audio samples from a Hugging Face dataset, prepares them for
+    transcription benchmarking, and manages temporary storage of audio files.
+    """
+    DEFAULT_AUDIO_PREAMBLE_TEMPLATE = "<|startoftranscript|><|{lang}|><|transcribe|><|notimestamps|>"
+    TEXT_FIELD_CANDIDATES = ['text', 'transcription', 'sentence']
+
+    def __init__(
+        self,
+        hf_dataset_name: str,
+        tokenizer: PreTrainedTokenizerBase,
+        hf_dataset_config: Optional[str] = None,
+        hf_dataset_split: str = "train",
+        language: str = "en",
+        preamble_template: Optional[str] = None,
+        audio_duration_limit_sec: Optional[float] = 30.0,
+        audio_column: str = "audio",
+        text_column: Optional[str] = None,
+        max_samples: Optional[int] = None
+    ):
+        self.tokenizer = tokenizer
+        self.hf_dataset_name = hf_dataset_name
+        self.hf_dataset_config = hf_dataset_config
+        self.hf_dataset_split = hf_dataset_split
+        self.language = language
+        self.preamble = (preamble_template or self.DEFAULT_AUDIO_PREAMBLE_TEMPLATE).format(lang=language)
+        self.audio_duration_limit_sec = audio_duration_limit_sec
+        self.audio_column = audio_column
+        self.text_column = text_column
+        self.max_samples = max_samples
+
+        self.temp_dir = tempfile.mkdtemp(prefix="fib_audio_cache_")
+        logger.info(f"Created temporary directory for audio files: {self.temp_dir}")
+
+        self.dataset_samples: List[Tuple[str, int, int, str]] = self._load_and_prepare_data()
+
+    def _find_text_column(self, features) -> str:
+        """Find the column containing the transcription text."""
+        if self.text_column and self.text_column in features:
+            return self.text_column
+        for candidate in self.TEXT_FIELD_CANDIDATES:
+            if candidate in features:
+                logger.info(f"Using '{candidate}' as text column for ASR dataset.")
+                return candidate
+        raise ValueError(f"Could not find a suitable text column (tried: {self.TEXT_FIELD_CANDIDATES}) in dataset features: {list(features.keys())}")
+
+    def _load_and_prepare_data(self) -> List[Tuple[str, int, int, str]]:
+        """Load and prepare audio data from a Hugging Face dataset."""
+        try:
+            dataset = load_dataset(
+                self.hf_dataset_name,
+                name=self.hf_dataset_config,
+                split=self.hf_dataset_split,
+                streaming=False,
+            )
+        except Exception as e:
+            logger.error(f"Failed to load dataset {self.hf_dataset_name}: {e}")
+            return []
+
+        if self.max_samples is not None:
+            dataset = dataset.select(range(min(self.max_samples, len(dataset))))
+
+        prepared_data = []
+        actual_text_column = self._find_text_column(dataset.features)
+
+        logger.info(f"Preparing ASR data from {self.hf_dataset_name} ({self.hf_dataset_split}). This may take a while...")
+        
+        processed_count = 0
+        skipped_duration = 0
+        skipped_missing_text = 0
+
+        for i, item in enumerate(dataset):
+            if self.audio_column not in item or not item[self.audio_column]:
+                logger.warning(f"Skipping item {i} due to missing or empty audio data in column '{self.audio_column}'.")
+                continue
+            
+            audio_data = item[self.audio_column]
+            
+            if not isinstance(audio_data, dict) or "array" not in audio_data or "sampling_rate" not in audio_data:
+                logger.warning(f"Skipping item {i} due to unexpected audio data format: {type(audio_data)}. Expected dict with 'array' and 'sampling_rate'.")
+                continue
+
+            y = np.array(audio_data["array"])
+            sr = audio_data["sampling_rate"]
+
+            if y.ndim > 1: # If stereo, convert to mono.
+                y = librosa.to_mono(y.T)
+
+            duration_s = librosa.get_duration(y=y, sr=sr)
+            if self.audio_duration_limit_sec and duration_s > self.audio_duration_limit_sec:
+                skipped_duration += 1
+                continue
+
+            reference_text = item.get(actual_text_column)
+            if not reference_text or not isinstance(reference_text, str):
+                skipped_missing_text +=1
+                continue
+            
+            # Save audio to a temporary WAV file. Using a unique name based on index to avoid collisions if multiple identical audios exist.
+            temp_audio_filename = os.path.join(self.temp_dir, f"audio_sample_{processed_count}.wav")
+            try:
+                soundfile.write(temp_audio_filename, y, sr, format="WAV")
+            except Exception as e:
+                logger.error(f"Failed to write temporary audio file for item {i}: {e}")
+                continue
+
+            prompt_len = len(self.tokenizer.encode(self.preamble))
+            output_len = len(self.tokenizer.encode(reference_text)) # Expected output tokens
+
+            prepared_data.append((self.preamble, prompt_len, output_len, temp_audio_filename))
+            processed_count += 1
+        
+        if skipped_duration > 0:
+            logger.info(f"Skipped {skipped_duration} audio samples due to duration limit ({self.audio_duration_limit_sec}s).")
+        if skipped_missing_text > 0:
+            logger.info(f"Skipped {skipped_missing_text} audio samples due to missing reference text.")
+        
+        logger.info(f"Successfully prepared {len(prepared_data)} ASR samples.")
+        return prepared_data
+
+    def generate_data(self, size: int) -> List[Tuple[str, int, int, str]]:
+        """
+        Generate random samples from the prepared dataset.
+        
+        Returns a list of tuples, where each tuple contains:
+        (preamble_text, prompt_len, output_len, audio_file_path)
+        """
+        if not self.dataset_samples:
+            logger.warning("ASR dataset is empty or failed to load. Returning no data.")
+            return []
+        
+        if len(self.dataset_samples) < size:
+            logger.warning(
+                f"Requested {size} samples, but ASR dataset only has {len(self.dataset_samples)}. "
+                f"Returning all available samples. Consider increasing --max-samples or using a larger dataset split."
+            )
+            return self.dataset_samples
+        return random.sample(self.dataset_samples, size)
+
+    def cleanup_temp_dir(self):
+        """Explicitly clean up temporary files."""
+        if hasattr(self, 'temp_dir') and os.path.exists(self.temp_dir):
+            try:
+                shutil.rmtree(self.temp_dir)
+                logger.info(f"Successfully cleaned up temporary audio directory: {self.temp_dir}")
+                self.temp_dir = None
+            except OSError as e:
+                logger.error(f"Error cleaning up temporary directory {self.temp_dir}: {e}")
+    
+    def __del__(self):
+        """Clean up temporary files on object destruction as a fallback."""
+        if hasattr(self, 'temp_dir') and self.temp_dir and os.path.exists(self.temp_dir):
+            logger.warning(
+                f"ASRDataset temporary directory {self.temp_dir} was not explicitly cleaned. "
+                "Attempting cleanup in __del__. Please ensure cleanup_temp_dir() is called."
+            )
+            self.cleanup_temp_dir()
 
 
 class ShareGPT(Data):


### PR DESCRIPTION
**Add Audio Transcription Benchmarking**

vLLM supports Whisper, since https://github.com/vllm-project/vllm/pull/12909 and TensorRT in https://github.com/NVIDIA/TensorRT-LLM/tree/release/0.19/examples/whisper (haven't personally tried this one).

Support ASR model benchmarking via `/v1/audio/transcriptions`.

Changes:
- New `openai-audio` backend
- `ASRDataset` class for loading/preparing ASR samples from Hugging Face datasets (e.g., LibriSpeech, Common Voice, AMI), including temporary file management. Mostly lifted from vLLM.
- CLI arguments (`--audio-dataset-name`, etc.) for ASR data configuration.
- Unfortunately, i had to modify some of `RequestFuncInput`, `main.py`, and `Client.py` to integrate the audio pipeline.
- Added `librosa`, `soundfile`, `datasets` dependencies. We can move these to an extra `[audio]` if necessary as well

Signed-off-by: Brayden Zhong <b8zhong@uwaterloo.ca>
Co-authored-by: @vincentzed

Example:

```
fib benchmark \
    --backend openai-audio \
    --model "openai/whisper-large-v3-turbo" \
    --base-url "http://localhost:8000" \
    --endpoint "/v1/audio/transcriptions" \
    --tokenizer "openai/whisper-large-v3-turbo" \
    \
    --audio-dataset-name "edinburghcstr/ami" \
    --audio-dataset-config "ihm" \
    --audio-dataset-split "test" \
    --audio-language "en" \
    --audio-duration-limit 29.5 \
    --audio-max-samples 500 \
    \
    --num-of-req 500

============ Serving Benchmark Result ============
Successful requests:                     500       
Benchmark duration (s):                  14.59     
Total input tokens:                      3500      
Total generated tokens:                  3050      
Request throughput (req/s):              34.27     
Input token throughput (tok/s):          239.88    
Output token throughput (tok/s):         209.04    
---------------Time to First Token----------------
Mean TTFT (ms):                          8803.45   
Median TTFT (ms):                        9122.14   
P99 TTFT (ms):                           12670.75  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          0.01      
Median TPOT (ms):                        0.00      
P99 TPOT (ms):                           0.02      
---------------Inter-token Latency----------------
Mean ITL (ms):                           0.00      
Median ITL (ms):                         0.00      
P99 ITL (ms):                            0.00      
==================================================
```