### PR TITLE
[FEAT] add otel support with detailed spans for chat completions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,24 @@ cd flexible-inference-bench
 pip install .
 ```
 
+## OpenTelemetry Integration
+The framework supports OpenTelemetry integration for distributed tracing. To enable it:
+
+1. Set the following environment variables:
+   ```bash
+   export OTEL_ENABLED=true
+   export OTEL_EXPORTER_OTLP_ENDPOINT=http://your-collector:4317  # Optional, defaults to localhost:4317
+   ```
+
+2. Each request will be traced with the following attributes (all prefixed with 'fib.' for easy identification):
+   - `fib.prompt.tokens`: Number of tokens in the input prompt
+   - `fib.image.count`: Number of images in the request
+   - `fib.image.sizes`: List of image sizes in bytes
+   - `fib.response.tokens`: Number of tokens in the response
+   - `fib.run.id`: Unique identifier for grouping requests from the same benchmark run
+
+3. The traces can be viewed in any OpenTelemetry-compatible backend (e.g., Jaeger, Zipkin, etc.)
+
 ## Usage
 After installing with the above instructions, the benchmarker can be invoked with `fib benchmark [options]`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,11 @@ dependencies = [
     "sentencepiece",
     "aiohttp",
     "pydantic",
-    "matplotlib"
+    "matplotlib",
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp",
+    "opentelemetry-instrumentation-aiohttp-client"
 ]
 
 classifiers = [

--- a/src/flexible_inference_benchmark/data_postprocessors/performance.py
+++ b/src/flexible_inference_benchmark/data_postprocessors/performance.py
@@ -16,7 +16,7 @@ def add_performance_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, stream, export_json=False) -> None:
+def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, stream, export_json=False) -> dict:
     actual_output_lens = []
     total_input = 0
     completed = 0
@@ -77,28 +77,31 @@ def calculate_metrics(input_requests, outputs, benchmark_duration, tokenizer, st
         print("{:<40} {:<10.2f}".format("P99 ITL (ms):", p99_itl_ms))
         print("=" * 50)
 
+    metrics = {
+        "successful_requests": completed,
+        "duration": benchmark_duration,
+        "total_input_tokens": total_input,
+        "total_generated_tokens": total_output,
+        "request_throughput": request_throughput,
+        "input_token_throughput": input_throughput,
+        "output_token_throughput": output_throughput,
+        "mean_ttft": mean_ttft_ms,
+        "median_ttft": median_ttft_ms,
+        "p99_ttft": p99_ttft_ms,
+        "mean_tpot": mean_tpot_ms,
+        "median_tpot": median_tpot_ms,
+        "p99_tpot": p99_tpot_ms,
+        "mean_itl": mean_itl_ms,
+        "median_itl": median_itl_ms,
+        "p99_itl": p99_itl_ms,
+    }
+
     if export_json:
-        data = {
-            "successful_requests": completed,
-            "duration": benchmark_duration,
-            "total_input_tokens": total_input,
-            "total_generated_tokens": total_output,
-            "request_throughput": request_throughput,
-            "input_token_throughput": input_throughput,
-            "output_token_throughput": output_throughput,
-            "mean_ttft": mean_ttft_ms,
-            "median_ttft": median_ttft_ms,
-            "p99_ttft": p99_ttft_ms,
-            "mean_tpot": mean_tpot_ms,
-            "median_tpot": median_tpot_ms,
-            "p99_tpot": p99_tpot_ms,
-            "mean_itl": mean_itl_ms,
-            "median_itl": median_itl_ms,
-            "p99_itl": p99_itl_ms,
-        }
         filename = "performance_data.json"
         with open(filename, "w") as f:
-            json.dump(data, f, indent=3)
+            json.dump(metrics, f, indent=3)
+
+    return metrics
 
 
 def run(args: argparse.Namespace):

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -9,9 +9,13 @@ from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field
 import aiohttp
 from tqdm.asyncio import tqdm
+from opentelemetry import trace
+from flexible_inference_benchmark.utils.telemetry import create_span_attributes
 
 AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
 
+# Get the tracer
+tracer = trace.get_tracer(__name__)
 
 class bcolors:
     OKBLUE = '\033[94m'
@@ -33,6 +37,7 @@ class RequestFuncInput(BaseModel):
     stream: bool = True
     cookies: Dict[str, str]
     logprobs: Optional[int] = None
+    run_id: Optional[str] = None
 
 
 class RequestFuncOutput(BaseModel):
@@ -72,7 +77,7 @@ async def async_request_tgi(
         if verbose:
             print_verbose(idx, request_func_input, st, 0, 0, True)
         try:
-            async with session.post(url=api_url, json=payload, verify_ssl=request_func_input.ssl) as response:
+            async with session.post(url=api_url, json=payload, ssl=request_func_input.ssl) as response:
                 if response.status == 200:
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -142,7 +147,7 @@ async def async_request_trt_llm(
         if verbose:
             print_verbose(idx, request_func_input, most_recent_timestamp, 0, 0, True)
         try:
-            async with session.post(url=api_url, json=payload, verify_ssl=request_func_input.ssl) as response:
+            async with session.post(url=api_url, json=payload, ssl=request_func_input.ssl) as response:
                 if response.status == 200:
                     async for chunk_bytes in response.content:
                         chunk_bytes = chunk_bytes.strip()
@@ -215,7 +220,7 @@ async def async_request_deepspeed_mii(
             print_verbose(idx, request_func_input, st, 0, 0, True)
         try:
             async with session.post(
-                url=request_func_input.api_url, json=payload, verify_ssl=request_func_input.ssl
+                url=request_func_input.api_url, json=payload, ssl=request_func_input.ssl
             ) as response:
                 if response.status == 200:
                     parsed_resp = await response.json()
@@ -278,7 +283,7 @@ async def async_request_openai_completions(
                 print_verbose(idx, request_func_input, st, 0, 0, True)
             try:
                 async with session.post(
-                    url=api_url, json=payload, headers=headers, verify_ssl=request_func_input.ssl
+                    url=api_url, json=payload, headers=headers, ssl=request_func_input.ssl
                 ) as response:
                     if response.status == 200:
                         async for chunk_bytes in response.content:
@@ -358,7 +363,7 @@ async def async_request_openai_completions(
                 print_verbose(idx, request_func_input, st, 0, 0, True)
             try:
                 async with session.post(
-                    url=api_url, json=payload, headers=headers, verify_ssl=request_func_input.ssl
+                    url=api_url, json=payload, headers=headers, ssl=request_func_input.ssl
                 ) as response:
                     if response.status == 200:
                         parsed_resp = await response.json()
@@ -405,100 +410,118 @@ async def async_request_openai_chat_completions(
     for media_item in request_func_input.media:
         content_body.append({"type": "image_url", "image_url": {"url": media_item}})
 
-    async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
-        assert not request_func_input.use_beam_search
-        payload = {
-            "model": request_func_input.model,
-            "messages": [{"role": "user", "content": content_body}],
-            "temperature": 0.0,
-            "max_tokens": request_func_input.output_len,
-            "stream": True,
-            "ignore_eos": request_func_input.ignore_eos,
-            "stream_options": {"include_usage": True},
-        }
-        if request_func_input.logprobs is not None:
-            payload["logprobs"] = True
-            payload["top_logprobs"] = int(request_func_input.logprobs)
-        headers = {"Content-Type": "application/json", "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
+    with tracer.start_as_current_span(
+        f"request_{idx}",
+        attributes=create_span_attributes(
+            prompt_tokens=request_func_input.prompt_len,
+            image_count=len(request_func_input.media) if request_func_input.media else 0,
+            image_sizes=[len(img) for img in request_func_input.media] if request_func_input.media else [],
+            response_tokens=0,  # Will be updated after response
+            run_id=request_func_input.run_id or "unknown"  # Provide default value for None
+        )
+    ) as span:
+        async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
+            assert not request_func_input.use_beam_search
+            payload = {
+                "model": request_func_input.model,
+                "messages": [{"role": "user", "content": content_body}],
+                "temperature": 0.0,
+                "max_tokens": request_func_input.output_len,
+                "stream": True,
+                "ignore_eos": request_func_input.ignore_eos,
+                "stream_options": {"include_usage": True},
+            }
+            if request_func_input.logprobs is not None:
+                payload["logprobs"] = True
+                payload["top_logprobs"] = int(request_func_input.logprobs)
+            headers = {"Content-Type": "application/json", "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
 
-        output = RequestFuncOutput()
-        output.prompt_len = request_func_input.prompt_len
+            output = RequestFuncOutput()
+            output.prompt_len = request_func_input.prompt_len
 
-        generated_text = ""
-        ttft = 0.0
-        st = time.perf_counter()
-        most_recent_timestamp = st
-        if verbose:
-            print_verbose(idx, request_func_input, st, 0, 0, True)
-        try:
-            async with session.post(
-                url=api_url, json=payload, headers=headers, verify_ssl=request_func_input.ssl
-            ) as response:
-                if response.status == 200:
-                    latency = 0.0
-                    async for chunk_bytes in response.content:
-                        chunk_bytes = chunk_bytes.strip()
-                        if not chunk_bytes:
-                            continue
+            generated_text = ""
+            ttft = 0.0
+            st = time.perf_counter()
+            most_recent_timestamp = st
+            if verbose:
+                print_verbose(idx, request_func_input, st, 0, 0, True)
+            try:
+                with tracer.start_as_current_span("http_request") as http_span:
+                    async with session.post(
+                        url=api_url, json=payload, headers=headers, ssl=request_func_input.ssl
+                    ) as response:
+                        if response.status == 200:
+                            latency = 0.0
+                            with tracer.start_as_current_span("response_processing") as process_span:
+                                async for chunk_bytes in response.content:
+                                    chunk_bytes = chunk_bytes.strip()
+                                    if not chunk_bytes:
+                                        continue
 
-                        chunk = remove_prefix(chunk_bytes.decode("utf-8"), "data: ")
-                        if chunk == "[DONE]":
-                            latency = time.perf_counter() - st
+                                    chunk = remove_prefix(chunk_bytes.decode("utf-8"), "data: ")
+                                    if chunk == "[DONE]":
+                                        latency = time.perf_counter() - st
+                                    else:
+                                        timestamp = time.perf_counter()
+                                        data = json.loads(chunk)
+
+                                        delta = data["choices"][0]["delta"] if len(data["choices"]) > 0 else None
+                                        content = delta.get("content", None) if delta is not None else None
+                                        reasoning_content = delta.get("reasoning_content", None) if delta is not None else None
+                                        if (content is not None or reasoning_content is not None) and not (
+                                            ttft == 0.0 and (content == '' or reasoning_content == '')
+                                        ):
+                                            if ttft == 0.0:
+                                                ttft = time.perf_counter() - st
+                                                output.ttft = ttft
+                                                process_span.set_attribute("fib.time_to_first_token", ttft)
+
+                                            else:
+                                                output.itl.append(timestamp - most_recent_timestamp)
+                                                process_span.set_attribute("fib.inter_token_latency", timestamp - most_recent_timestamp)
+                                            if content:
+                                                generated_text += content
+                                            elif reasoning_content:
+                                                generated_text += reasoning_content
+                                            most_recent_timestamp = timestamp
+
+                                        if "usage" in data:
+                                            if data["usage"]["completion_tokens"]:
+                                                output.output_len = int(data["usage"]["completion_tokens"])
+                                                process_span.set_attribute("fib.completion_tokens", output.output_len)
+                                            if data["usage"]["prompt_tokens"]:
+                                                output.prompt_len = int(data["usage"]["prompt_tokens"])
+                                                process_span.set_attribute("fib.prompt_tokens", output.prompt_len)
+
+                            output.generated_text = generated_text
+                            output.success = True
+                            output.latency = latency
+                            span.set_attribute("fib.total_latency", latency)
+                            span.set_attribute("fib.total_tokens", len(generated_text))
+
+                            if verbose:
+                                print_verbose(idx, request_func_input, 0, most_recent_timestamp, output.latency, False)
                         else:
-                            timestamp = time.perf_counter()
-                            data = json.loads(chunk)
+                            output.error = response.reason or ""
+                            output.success = False
+                            span.set_attribute("fib.error", output.error)
 
-                            delta = data["choices"][0]["delta"] if len(data["choices"]) > 0 else None
-                            content = delta.get("content", None) if delta is not None else None
-                            reasoning_content = delta.get("reasoning_content", None) if delta is not None else None
-                            # Make sure to include the content if it's not None
-                            # Since EOS can translate to an empty string, include `content == ""`
-                            # as long as it's not the first token
-                            if (content is not None or reasoning_content is not None) and not (
-                                ttft == 0.0 and (content == '' or reasoning_content == '')
-                            ):
-                                # First token
-                                if ttft == 0.0:
-                                    ttft = time.perf_counter() - st
-                                    output.ttft = ttft
+            except aiohttp.ClientConnectorError:
+                output.success = False
+                output.error = "connection error, please verify the server is running"
+                span.set_attribute("fib.error", output.error)
 
-                                # Decoding phase
-                                else:
-                                    output.itl.append(timestamp - most_recent_timestamp)
-                                if content:
-                                    generated_text += content
-                                elif reasoning_content:
-                                    generated_text += reasoning_content
-                                most_recent_timestamp = timestamp
+            except Exception:  # pylint: disable=broad-except
+                output.success = False
+                exc_info = sys.exc_info()
+                output.error = "".join(traceback.format_exception(*exc_info))
+                span.set_attribute("fib.error", output.error)
 
-                            if "usage" in data:
-                                if data["usage"]["completion_tokens"]:
-                                    output.output_len = int(data["usage"]["completion_tokens"])
-                                if data["usage"]["prompt_tokens"]:
-                                    output.prompt_len = int(data["usage"]["prompt_tokens"])
+            if pbar:
+                with tracer.start_as_current_span("progress_update") as pbar_span:
+                    pbar.update(1)
 
-                    output.generated_text = generated_text
-                    output.success = True
-                    output.latency = latency
-
-                    if verbose:
-                        print_verbose(idx, request_func_input, 0, most_recent_timestamp, output.latency, False)
-                else:
-                    output.error = response.reason or ""
-                    output.success = False
-
-        except aiohttp.ClientConnectorError:
-            output.success = False
-            output.error = "connection error, please verify the server is running"
-
-        except Exception:  # pylint: disable=broad-except
-            output.success = False
-            exc_info = sys.exc_info()
-            output.error = "".join(traceback.format_exception(*exc_info))
-
-    if pbar:
-        pbar.update(1)
-    return output
+            return output
 
 
 async def async_request_cserve_debug(
@@ -530,7 +553,7 @@ async def async_request_cserve_debug(
                 print_verbose(idx, request_func_input, st, 0, 0, True)
             try:
                 async with session.post(
-                    url=api_url, json=payload, headers=headers, verify_ssl=request_func_input.ssl
+                    url=api_url, json=payload, headers=headers, ssl=request_func_input.ssl
                 ) as response:
                     if response.status == 200:
                         async for chunk_bytes in response.content:
@@ -596,7 +619,7 @@ async def async_request_cserve_debug(
                 print_verbose(idx, request_func_input, st, 0, 0, True)
             try:
                 async with session.post(
-                    url=api_url, json=payload, headers=headers, verify_ssl=request_func_input.ssl
+                    url=api_url, json=payload, headers=headers, ssl=request_func_input.ssl
                 ) as response:
                     if response.status == 200:
                         parsed_resp = await response.json()

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -450,7 +450,7 @@ async def async_request_openai_chat_completions(
             if verbose:
                 print_verbose(idx, request_func_input, st, 0, 0, True)
             try:
-                with tracer.start_as_current_span("http_request") as http_span:
+                with tracer.start_as_current_span("http_request"):
                     async with session.post(
                         url=api_url, json=payload, headers=headers, ssl=request_func_input.ssl
                     ) as response:
@@ -526,7 +526,7 @@ async def async_request_openai_chat_completions(
                 span.set_attribute("fib.error", output.error)
 
             if pbar:
-                with tracer.start_as_current_span("progress_update") as pbar_span:
+                with tracer.start_as_current_span("progress_update"):
                     pbar.update(1)
 
             return output

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -17,6 +17,7 @@ AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=6 * 60 * 60)
 # Get the tracer
 tracer = trace.get_tracer(__name__)
 
+
 class bcolors:
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
@@ -417,8 +418,8 @@ async def async_request_openai_chat_completions(
             image_count=len(request_func_input.media) if request_func_input.media else 0,
             image_sizes=[len(img) for img in request_func_input.media] if request_func_input.media else [],
             response_tokens=0,  # Will be updated after response
-            run_id=request_func_input.run_id or "unknown"  # Provide default value for None
-        )
+            run_id=request_func_input.run_id or "unknown",  # Provide default value for None
+        ),
     ) as span:
         async with aiohttp.ClientSession(timeout=AIOHTTP_TIMEOUT) as session:
             assert not request_func_input.use_beam_search
@@ -434,7 +435,10 @@ async def async_request_openai_chat_completions(
             if request_func_input.logprobs is not None:
                 payload["logprobs"] = True
                 payload["top_logprobs"] = int(request_func_input.logprobs)
-            headers = {"Content-Type": "application/json", "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"}
+            headers = {
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+            }
 
             output = RequestFuncOutput()
             output.prompt_len = request_func_input.prompt_len
@@ -467,7 +471,9 @@ async def async_request_openai_chat_completions(
 
                                         delta = data["choices"][0]["delta"] if len(data["choices"]) > 0 else None
                                         content = delta.get("content", None) if delta is not None else None
-                                        reasoning_content = delta.get("reasoning_content", None) if delta is not None else None
+                                        reasoning_content = (
+                                            delta.get("reasoning_content", None) if delta is not None else None
+                                        )
                                         if (content is not None or reasoning_content is not None) and not (
                                             ttft == 0.0 and (content == '' or reasoning_content == '')
                                         ):
@@ -478,7 +484,9 @@ async def async_request_openai_chat_completions(
 
                                             else:
                                                 output.itl.append(timestamp - most_recent_timestamp)
-                                                process_span.set_attribute("fib.inter_token_latency", timestamp - most_recent_timestamp)
+                                                process_span.set_attribute(
+                                                    "fib.inter_token_latency", timestamp - most_recent_timestamp
+                                                )
                                             if content:
                                                 generated_text += content
                                             elif reasoning_content:

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -1,6 +1,7 @@
 # pylint: disable=too-many-positional-arguments
 import asyncio
 import logging
+import uuid
 from typing import List, Tuple, Callable, Optional, Any, Coroutine, Union, Dict
 import random
 from tqdm import tqdm
@@ -38,6 +39,7 @@ class Client:
         max_concurrent: Optional[int],
         wave: Optional[List[int]],
         logprobs: Optional[int],
+        run_id: Optional[str] = None,
     ):
         self.backend = backend
         self.api_url = api_url
@@ -55,6 +57,7 @@ class Client:
         if wave:
             self.wave_min, self.wave_max, self.wave_sustain = wave
         self.logprobs = logprobs
+        self.run_id = run_id or str(uuid.uuid4())
 
     @property
     def request_func(
@@ -148,6 +151,7 @@ class Client:
                 stream=self.stream,
                 cookies=self.cookies,
                 logprobs=self.logprobs,
+                run_id=self.run_id,
             )
             for (data_sample, media_sample) in zip(data, requests_media)
         ]
@@ -189,4 +193,4 @@ class Client:
             cookies=self.cookies,
             logprobs=self.logprobs,
         )
-        return await self.send_request(0, data, 0, None, None)
+        return await self.send_request(-1, data, 0, None, None)

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -10,6 +10,7 @@ import time
 from typing import List, Any, Tuple, Union
 from concurrent.futures import ThreadPoolExecutor
 import base64
+import uuid
 import requests
 from tqdm import tqdm
 import numpy as np
@@ -33,8 +34,6 @@ from flexible_inference_benchmark.data_postprocessors.itl import add_itl_parser
 from flexible_inference_benchmark.utils.telemetry import setup_telemetry
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind
-
-import uuid
 
 logger = logging.getLogger(__name__)
 

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -559,12 +559,13 @@ def run_main(args: argparse.Namespace) -> None:
         kind=SpanKind.INTERNAL,
         attributes={
             "fib.run.id": run_id,
-            "fib.command": json.dumps({
-                "subcommand": args.subcommand,
-                "args": {k: v for k, v in vars(args).items() 
-                        if k not in ['subcommand'] and v is not None}
-            })
-        }
+            "fib.command": json.dumps(
+                {
+                    "subcommand": args.subcommand,
+                    "args": {k: v for k, v in vars(args).items() if k not in ['subcommand'] and v is not None},
+                }
+            ),
+        },
     ) as span:
         requests_times = generate_request_times(args)
         size = len(requests_times)
@@ -635,7 +636,9 @@ def run_main(args: argparse.Namespace) -> None:
             }
 
             # Calculate performance metrics and add them as span attributes
-            metrics = calculate_metrics(output["inputs"], output["outputs"], output["time"], tokenizer, output["stream"])
+            metrics = calculate_metrics(
+                output["inputs"], output["outputs"], output["time"], tokenizer, output["stream"]
+            )
             # Add metrics as a single JSON blob attribute
             span.set_attribute("fib.metrics", json.dumps(metrics))
 

--- a/src/flexible_inference_benchmark/utils/telemetry.py
+++ b/src/flexible_inference_benchmark/utils/telemetry.py
@@ -1,0 +1,62 @@
+import os
+from typing import Optional
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.resources import Resource, SERVICE_NAME, get_aggregated_resources
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrumentor
+
+DEFAULT_SERVICE_NAME = "centml-fib"
+
+def setup_telemetry() -> None:
+    """
+    Set up OpenTelemetry tracing with OTLP exporter.
+    The service name is determined in the following order:
+    1. OTEL_SERVICE_NAME environment variable
+    2. DEFAULT_SERVICE_NAME
+    """
+    # Check if telemetry is enabled
+    if os.getenv("OTEL_ENABLED", "false").lower() != "true":
+        return
+
+    # Get service name from environment or use default
+    service_name = os.getenv("OTEL_SERVICE_NAME", DEFAULT_SERVICE_NAME)
+    
+    # Create resource with service name
+    resource = Resource.create({SERVICE_NAME: service_name})
+    
+    # Set up the tracer provider
+    provider = TracerProvider(resource=resource)
+
+    # Set up the OTLP exporter
+    otlp_exporter = OTLPSpanExporter()
+    
+    # Add the span processor to the tracer provider
+    provider.add_span_processor(BatchSpanProcessor(otlp_exporter, max_queue_size=10000))
+    
+    # Set the tracer provider
+    trace.set_tracer_provider(provider)
+    
+    # Instrument aiohttp client
+    AioHttpClientInstrumentor().instrument()
+
+def create_span_attributes(
+    prompt_tokens: int,
+    image_count: int,
+    image_sizes: list[int],
+    response_tokens: int,
+    run_id: str
+) -> dict:
+    """
+    Create a dictionary of span attributes for a request.
+    All attributes are prefixed with 'fib.' for easy identification.
+    Token counts are used instead of character sizes for better LLM metrics.
+    """
+    return {
+        "fib.prompt.tokens": prompt_tokens,
+        "fib.image.count": image_count,
+        "fib.image.sizes": image_sizes,
+        "fib.response.tokens": response_tokens,
+        "fib.run.id": run_id
+    } 

--- a/src/flexible_inference_benchmark/utils/telemetry.py
+++ b/src/flexible_inference_benchmark/utils/telemetry.py
@@ -45,7 +45,7 @@ def setup_telemetry() -> None:
 
 def create_span_attributes(
     prompt_tokens: int, image_count: int, image_sizes: list[int], response_tokens: int, run_id: str
-) -> dict:
+) -> dict[str, int | list[int] | str]:
     """
     Create a dictionary of span attributes for a request.
     All attributes are prefixed with 'fib.' for easy identification.

--- a/src/flexible_inference_benchmark/utils/telemetry.py
+++ b/src/flexible_inference_benchmark/utils/telemetry.py
@@ -9,6 +9,7 @@ from opentelemetry.instrumentation.aiohttp_client import AioHttpClientInstrument
 
 DEFAULT_SERVICE_NAME = "centml-fib"
 
+
 def setup_telemetry() -> None:
     """
     Set up OpenTelemetry tracing with OTLP exporter.
@@ -22,31 +23,28 @@ def setup_telemetry() -> None:
 
     # Get service name from environment or use default
     service_name = os.getenv("OTEL_SERVICE_NAME", DEFAULT_SERVICE_NAME)
-    
+
     # Create resource with service name
     resource = Resource.create({SERVICE_NAME: service_name})
-    
+
     # Set up the tracer provider
     provider = TracerProvider(resource=resource)
 
     # Set up the OTLP exporter
     otlp_exporter = OTLPSpanExporter()
-    
+
     # Add the span processor to the tracer provider
     provider.add_span_processor(BatchSpanProcessor(otlp_exporter, max_queue_size=10000))
-    
+
     # Set the tracer provider
     trace.set_tracer_provider(provider)
-    
+
     # Instrument aiohttp client
     AioHttpClientInstrumentor().instrument()
 
+
 def create_span_attributes(
-    prompt_tokens: int,
-    image_count: int,
-    image_sizes: list[int],
-    response_tokens: int,
-    run_id: str
+    prompt_tokens: int, image_count: int, image_sizes: list[int], response_tokens: int, run_id: str
 ) -> dict:
     """
     Create a dictionary of span attributes for a request.
@@ -58,5 +56,5 @@ def create_span_attributes(
         "fib.image.count": image_count,
         "fib.image.sizes": image_sizes,
         "fib.response.tokens": response_tokens,
-        "fib.run.id": run_id
-    } 
+        "fib.run.id": run_id,
+    }


### PR DESCRIPTION
This adds otel support with detailed tracing for chat completions backend. It can be extended to other backend functions if necessary. 

**WHY**
Get more granular view of each request in a easy to consume way. 

**Examples**

Every run is identified by a run_id. The whole experiment is recorded as a single span like so:
![Screenshot 2025-05-22 at 4 18 42 PM](https://github.com/user-attachments/assets/4625bee2-fa5a-4c8d-bd3c-ff8cde1c5775)

Every request is individually recorded and its data can be aggregated. 
![Screenshot 2025-05-22 at 4 23 54 PM](https://github.com/user-attachments/assets/3584f9fb-44ad-4cda-8c48-4315399c0cd8)

Additional information is available on each request as well.. but it all depends on what you are looking for =) 