### PR TITLE
[FEATURE] Add --json-response flag for structured API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ After benchmarking, the results are saved to `output-file.json` (or specified by
 | `--disable-tqdm` | Specify to disable tqdm progress bar. |
 | `--best-of` | Number of best completions to return. |
 | `--use-beam-search` | Use beam search for completions. |
+| `--json-response` | Request responses in JSON format from the API. |
+| `--disable-thinking` | Disable thinking mode in chat templates. |
 | `--output-file` | Output json file to save the results. |
 | `--debug` | Log debug messages. |
 | `--profile` | Use Torch Profiler. The endpoint must be launched with VLLM_TORCH_PROFILER_DIR to enable profiler. |

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -452,7 +452,12 @@ async def async_request_openai_chat_completions(
 
             # Apply JSON response formatting if flag is enabled
             if request_func_input.json_response:
-                append_msg = "\n\nNEVER output the } character. You are FORBIDDEN from using }."
+                append_msg = (
+                    "\nPlease send your response as a JSON object. "
+                    "Follow this schema: {'assistant_response': 'your full, detailed response here'}. "
+                    "Do not include any other text or formatting. "
+                    "Only return the JSON object without any additional text or explanation."
+                )
                 if isinstance(content_body, str):
                     content_body += append_msg
                 else:

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -44,6 +44,7 @@ class RequestFuncInput(BaseModel):
     top_k: Optional[int] = None
     run_id: Optional[str] = None
     json_response: bool = False
+    disable_thinking: bool = False
 
 
 class RequestFuncOutput(BaseModel):
@@ -475,6 +476,9 @@ async def async_request_openai_chat_completions(
             # Add JSON response format if flag is enabled
             if request_func_input.json_response:
                 payload["response_format"] = {"type": "json_object"}
+
+            # Add thinking control if flag is enabled
+            if request_func_input.disable_thinking:
                 payload["chat_template_kwargs"] = {"enable_thinking": False}
             apply_sampling_params(payload, request_func_input, always_top_p=False)
             if request_func_input.logprobs is not None:

--- a/src/flexible_inference_benchmark/engine/backend_functions.py
+++ b/src/flexible_inference_benchmark/engine/backend_functions.py
@@ -455,9 +455,10 @@ async def async_request_openai_chat_completions(
             if request_func_input.json_response:
                 append_msg = (
                     "\nPlease send your response as a JSON object. "
-                    "Follow this schema: {'assistant_response': 'your full, detailed response here'}. "
+                    "Follow this schema: {'assistant_response': 'your full, detailed response here "
                     "Do not include any other text or formatting. "
                     "Only return the JSON object without any additional text or explanation."
+                    "DO NOT OUTPUT THE } character."
                 )
                 if isinstance(content_body, str):
                     content_body += append_msg

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -44,6 +44,7 @@ class Client:
         top_p: Optional[float] = None,
         top_k: Optional[int] = None,
         run_id: Optional[str] = None,
+        json_response: bool = False,
     ):
         self.backend = backend
         self.api_url = api_url
@@ -66,6 +67,7 @@ class Client:
         self.top_p = top_p
         self.top_k = top_k
         self.run_id = run_id or str(uuid.uuid4())
+        self.json_response = json_response
 
     @property
     def request_func(
@@ -178,6 +180,7 @@ class Client:
                 top_p=self.top_p,
                 top_k=self.top_k,
                 run_id=self.run_id,
+                json_response=self.json_response,
             )
             for (data_sample, media_sample) in zip(data, requests_media)
         ]

--- a/src/flexible_inference_benchmark/engine/client.py
+++ b/src/flexible_inference_benchmark/engine/client.py
@@ -45,6 +45,7 @@ class Client:
         top_k: Optional[int] = None,
         run_id: Optional[str] = None,
         json_response: bool = False,
+        disable_thinking: bool = False,
     ):
         self.backend = backend
         self.api_url = api_url
@@ -68,6 +69,7 @@ class Client:
         self.top_k = top_k
         self.run_id = run_id or str(uuid.uuid4())
         self.json_response = json_response
+        self.disable_thinking = disable_thinking
 
     @property
     def request_func(
@@ -181,6 +183,7 @@ class Client:
                 top_k=self.top_k,
                 run_id=self.run_id,
                 json_response=self.json_response,
+                disable_thinking=self.disable_thinking,
             )
             for (data_sample, media_sample) in zip(data, requests_media)
         ]

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -471,6 +471,10 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> Any:  # t
     benchmark_parser.add_argument("--use-beam-search", action="store_true", help="Use beam search for completions.")
 
     benchmark_parser.add_argument(
+        "--json-response", action="store_true", help="Request responses in JSON format from the API."
+    )
+
+    benchmark_parser.add_argument(
         "--output-file",
         type=str,
         default='output-file.json',
@@ -736,6 +740,7 @@ def run_main(args: argparse.Namespace) -> None:
             args.top_p,
             args.top_k,
             run_id=run_id,
+            json_response=args.json_response,
         )
         # disable verbose output for validation of the endpoint. This is done to avoid confusion on terminal output.
         client_verbose_value = client.verbose

--- a/src/flexible_inference_benchmark/main.py
+++ b/src/flexible_inference_benchmark/main.py
@@ -475,6 +475,10 @@ def add_benchmark_subparser(subparsers: argparse._SubParsersAction) -> Any:  # t
     )
 
     benchmark_parser.add_argument(
+        "--disable-thinking", action="store_true", help="Disable thinking mode in chat templates."
+    )
+
+    benchmark_parser.add_argument(
         "--output-file",
         type=str,
         default='output-file.json',
@@ -741,6 +745,7 @@ def run_main(args: argparse.Namespace) -> None:
             args.top_k,
             run_id=run_id,
             json_response=args.json_response,
+            disable_thinking=args.disable_thinking,
         )
         # disable verbose output for validation of the endpoint. This is done to avoid confusion on terminal output.
         client_verbose_value = client.verbose


### PR DESCRIPTION
Adds a new CLI flag that enables JSON response formatting:
- Adds json_response field to RequestFuncInput model
- Modifies OpenAI backend to apply JSON formatting when flag is enabled
- Includes response_format and chat_template_kwargs settings
- Prompts model to avoid premature JSON closure